### PR TITLE
Fix test_headers: missing #include <boost/units/quantity.hpp>

### DIFF
--- a/include/boost/units/quantity.hpp
+++ b/include/boost/units/quantity.hpp
@@ -85,7 +85,7 @@ struct disable_if_is_same<T, T> {};
 }
  
 /// class declaration
-template<class Unit,class Y = double>
+template<class Unit,class Y>
 class quantity
 {
         // base units are not the same as units.

--- a/include/boost/units/systems/si/codata/alpha_constants.hpp
+++ b/include/boost/units/systems/si/codata/alpha_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_ALPHA_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_ALPHA_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/deuteron_constants.hpp
+++ b/include/boost/units/systems/si/codata/deuteron_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_DEUTERON_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_DEUTERON_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/electromagnetic_constants.hpp
+++ b/include/boost/units/systems/si/codata/electromagnetic_constants.hpp
@@ -18,6 +18,7 @@
 ///   CODATA 2006 values as of 2007/03/30
 ///
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/electron_constants.hpp
+++ b/include/boost/units/systems/si/codata/electron_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_ELECTRON_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_ELECTRON_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/helion_constants.hpp
+++ b/include/boost/units/systems/si/codata/helion_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_HELION_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_HELION_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/muon_constants.hpp
+++ b/include/boost/units/systems/si/codata/muon_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_MUON_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_MUON_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/neutron_constants.hpp
+++ b/include/boost/units/systems/si/codata/neutron_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_NEUTRON_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_NEUTRON_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/physico-chemical_constants.hpp
+++ b/include/boost/units/systems/si/codata/physico-chemical_constants.hpp
@@ -12,6 +12,7 @@
 #define BOOST_UNITS_CODATA_PHYSICO_CHEMICAL_CONSTANTS_HPP
 
 #include <boost/units/pow.hpp>
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/proton_constants.hpp
+++ b/include/boost/units/systems/si/codata/proton_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_PROTON_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_PROTON_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/tau_constants.hpp
+++ b/include/boost/units/systems/si/codata/tau_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_TAU_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_TAU_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/triton_constants.hpp
+++ b/include/boost/units/systems/si/codata/triton_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_TRITON_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_TRITON_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/systems/si/codata/universal_constants.hpp
+++ b/include/boost/units/systems/si/codata/universal_constants.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_UNITS_CODATA_UNIVERSAL_CONSTANTS_HPP
 #define BOOST_UNITS_CODATA_UNIVERSAL_CONSTANTS_HPP
 
+#include <boost/units/quantity.hpp>
 #include <boost/units/static_constant.hpp>
 
 #include <boost/units/systems/detail/constants.hpp>

--- a/include/boost/units/units_fwd.hpp
+++ b/include/boost/units/units_fwd.hpp
@@ -49,7 +49,7 @@ template<class T> struct is_unit;
 template<class T,class Dim> struct is_unit_of_dimension;
 template<class T,class System> struct is_unit_of_system;
 
-template<class Unit,class Y> class quantity;
+template<class Unit,class Y = double> class quantity;
 
 template<class System,class Y> struct dimensionless_quantity;
 template<class T> struct is_quantity;


### PR DESCRIPTION
 `#include <boost/units/quantity.hpp>` was missing in codata headers (not self-contained).

Move quantity template class default argument from `quantity.hpp` to `units_fwd.hpp`.
It may be necessary to do the same for other forward declarations.
