### PR TITLE
Fix unused variable warning

### DIFF
--- a/test/test_dimensionless_ice1.cpp
+++ b/test/test_dimensionless_ice1.cpp
@@ -8,13 +8,14 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/units/systems/si/base.hpp>
 #include <boost/units/quantity.hpp>
 
 void foo()
 {
     boost::units::quantity<boost::units::si::dimensionless> d = boost::units::quantity< boost::units::si::dimensionless >();
-    (void) d;
+    boost::ignore_unused(d);
 }
 
 #include <boost/test/test_tools.hpp>


### PR DESCRIPTION
Fix trivial unused variable warning in test/test_dimensionless_ice1.cpp.
