### PR TITLE
Add constexpr support

### DIFF
--- a/example/autoprefixes.cpp
+++ b/example/autoprefixes.cpp
@@ -105,8 +105,8 @@ int main()
 
   // Note that scalar dimensionless values are *not* prefixed automatically by the engineering_prefix or binary_prefix iostream manipulators.
   //[autoprefixes_snippet_3
-  const double s1 = 2345.6;
-  const long x1 = 23456;
+  BOOST_CONSTEXPR_OR_CONST double s1 = 2345.6;
+  BOOST_CONSTEXPR_OR_CONST long x1 = 23456;
   cout << engineering_prefix << s1 << endl; // 2345.6
   cout << engineering_prefix << x1 << endl; // 23456
 
@@ -115,7 +115,7 @@ int main()
   //] [/autoprefixes_snippet_3]
 
   //[autoprefixes_snippet_4
-  const length L; // A unit of length (but not a quantity of length).
+  BOOST_CONSTEXPR_OR_CONST length L; // A unit of length (but not a quantity of length).
   cout << L << endl; // Default length unit is meter,
   // but default is symbol format so output is just "m".
   cout << name_format << L << endl; // default length name is "meter".

--- a/example/autoprefixes.cpp
+++ b/example/autoprefixes.cpp
@@ -54,20 +54,20 @@ meter
 
 struct byte_base_unit : boost::units::base_unit<byte_base_unit, boost::units::dimensionless_type, 3>
 {
-  static const char* name() { return("byte"); }
-  static const char* symbol() { return("b"); }
+  static BOOST_CONSTEXPR const char* name() { return("byte"); }
+  static BOOST_CONSTEXPR const char* symbol() { return("b"); }
 };
 
 struct thing_base_unit : boost::units::base_unit<thing_base_unit, boost::units::dimensionless_type, 4>
 {
-  static const char* name() { return("thing"); }
-  static const char* symbol() { return(""); }
+  static BOOST_CONSTEXPR const char* name() { return("thing"); }
+  static BOOST_CONSTEXPR const char* symbol() { return(""); }
 };
 
 struct euro_base_unit : boost::units::base_unit<euro_base_unit, boost::units::dimensionless_type, 5>
 {
-  static const char* name() { return("EUR"); }
-  static const char* symbol() { return("€"); }
+  static BOOST_CONSTEXPR const char* name() { return("EUR"); }
+  static BOOST_CONSTEXPR const char* symbol() { return("€"); }
 };
 
 int main()

--- a/example/complex.cpp
+++ b/example/complex.cpp
@@ -72,10 +72,10 @@ class complex
     public:
         typedef complex<T>  this_type;
         
-        complex(const T& r = 0,const T& i = 0) : r_(r),i_(i) { }
-        complex(const this_type& source) : r_(source.r_),i_(source.i_) { }
+        BOOST_CONSTEXPR complex(const T& r = 0,const T& i = 0) : r_(r),i_(i) { }
+        BOOST_CONSTEXPR complex(const this_type& source) : r_(source.r_),i_(source.i_) { }
         
-        this_type& operator=(const this_type& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const this_type& source)
         {
             if (this == &source) return *this;
             
@@ -85,59 +85,59 @@ class complex
             return *this;
         }
         
-        T& real()                   { return r_; }
-        T& imag()                   { return i_; }
+        BOOST_CXX14_CONSTEXPR T& real()             { return r_; }
+        BOOST_CXX14_CONSTEXPR T& imag()             { return i_; }
         
-        const T& real() const       { return r_; }
-        const T& imag() const       { return i_; }
+        BOOST_CONSTEXPR const T& real() const       { return r_; }
+        BOOST_CONSTEXPR const T& imag() const       { return i_; }
 
-        this_type& operator+=(const T& val)
+        BOOST_CXX14_CONSTEXPR this_type& operator+=(const T& val)
         {
             r_ += val;
             return *this;
         }
         
-        this_type& operator-=(const T& val)
+        BOOST_CXX14_CONSTEXPR this_type& operator-=(const T& val)
         {
             r_ -= val;
             return *this;
         }
         
-        this_type& operator*=(const T& val)
+        BOOST_CXX14_CONSTEXPR this_type& operator*=(const T& val)
         {
             r_ *= val;
             i_ *= val;
             return *this;
         }
         
-        this_type& operator/=(const T& val)
+        BOOST_CXX14_CONSTEXPR this_type& operator/=(const T& val)
         {
             r_ /= val;
             i_ /= val;
             return *this;
         }
         
-        this_type& operator+=(const this_type& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator+=(const this_type& source)
         {
             r_ += source.r_;
             i_ += source.i_;
             return *this;
         }
         
-        this_type& operator-=(const this_type& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator-=(const this_type& source)
         {
             r_ -= source.r_;
             i_ -= source.i_;
             return *this;
         }
         
-        this_type& operator*=(const this_type& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator*=(const this_type& source)
         {
             *this = *this * source;
             return *this;
         }
         
-        this_type& operator/=(const this_type& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator/=(const this_type& source)
         {
             *this = *this / source;
             return *this;
@@ -164,6 +164,7 @@ namespace boost {
 namespace units {
 
 template<class X>
+BOOST_CONSTEXPR
 complex<typename unary_plus_typeof_helper<X>::type>
 operator+(const complex<X>& x)
 {
@@ -173,6 +174,7 @@ operator+(const complex<X>& x)
 }
 
 template<class X>
+BOOST_CONSTEXPR
 complex<typename unary_minus_typeof_helper<X>::type>
 operator-(const complex<X>& x)
 {
@@ -182,6 +184,7 @@ operator-(const complex<X>& x)
 }
 
 template<class X,class Y>
+BOOST_CONSTEXPR
 complex<typename add_typeof_helper<X,Y>::type>
 operator+(const complex<X>& x,const complex<Y>& y)
 {
@@ -191,6 +194,7 @@ operator+(const complex<X>& x,const complex<Y>& y)
 }
 
 template<class X,class Y>
+BOOST_CONSTEXPR
 complex<typename boost::units::subtract_typeof_helper<X,Y>::type>
 operator-(const complex<X>& x,const complex<Y>& y)
 {
@@ -200,6 +204,7 @@ operator-(const complex<X>& x,const complex<Y>& y)
 }
 
 template<class X,class Y>
+BOOST_CONSTEXPR
 complex<typename boost::units::multiply_typeof_helper<X,Y>::type>
 operator*(const complex<X>& x,const complex<Y>& y)
 {
@@ -226,6 +231,7 @@ operator*(const complex<X>& x,const complex<Y>& y)
 }
 
 template<class X,class Y>
+BOOST_CONSTEXPR
 complex<typename boost::units::divide_typeof_helper<X,Y>::type>
 operator/(const complex<X>& x,const complex<Y>& y)
 {
@@ -376,7 +382,7 @@ int main(void)
     //[complex_snippet_1
     typedef quantity<length,complex<double> >     length_dimension;
         
-    length_dimension    L(complex<double>(2.0,1.0)*meters);
+    BOOST_CONSTEXPR_OR_CONST length_dimension    L(complex<double>(2.0,1.0)*meters);
     //]
     
     std::cout << "+L      = " << +L << std::endl
@@ -396,7 +402,7 @@ int main(void)
     //[complex_snippet_2
     typedef complex<quantity<length> >     length_dimension;
         
-    length_dimension    L(2.0*meters,1.0*meters);
+    BOOST_CONSTEXPR_OR_CONST length_dimension    L(2.0*meters,1.0*meters);
     //]
     
     std::cout << "+L      = " << +L << std::endl

--- a/example/conversion.cpp
+++ b/example/conversion.cpp
@@ -62,21 +62,21 @@ int main()
     {
     // implicit value_type conversions
     //[conversion_snippet_1
-    quantity<si::length>     L1 = quantity<si::length,int>(int(2.5)*si::meters);
-    quantity<si::length,int> L2(quantity<si::length,double>(2.5*si::meters));
+    BOOST_CONSTEXPR_OR_CONST quantity<si::length>       L1 = quantity<si::length,int>(int(2.5)*si::meters);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::length,int>   L2(quantity<si::length,double>(2.5*si::meters));
     //]
     
     //[conversion_snippet_3
-    quantity<si::length,int> L3 = static_cast<quantity<si::length,int> >(L1);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::length,int>   L3 = static_cast<quantity<si::length,int> >(L1);
     //]
     
     //[conversion_snippet_4
-    quantity<cgs::length>    L4 = static_cast<quantity<cgs::length> >(L1);
+    BOOST_CONSTEXPR_OR_CONST quantity<cgs::length>      L4 = static_cast<quantity<cgs::length> >(L1);
     //]
     
-    quantity<si::length,int> L5(4*si::meters),
-                             L6(5*si::meters);
-    quantity<cgs::length>    L7(L1);
+    quantity<si::length,int>                            L5(4*si::meters),
+                                                        L6(5*si::meters);
+    BOOST_CONSTEXPR_OR_CONST quantity<cgs::length>      L7(L1);
     
     swap(L5,L6);
     
@@ -93,16 +93,16 @@ int main()
     // test explicit unit system conversion
     {
     //[conversion_snippet_5
-    quantity<si::volume>    vs(1.0*pow<3>(si::meter));      
-    quantity<cgs::volume>   vc(vs);
-    quantity<si::volume>    vs2(vc);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::volume>   vs(1.0*pow<3>(si::meter));      
+    BOOST_CONSTEXPR_OR_CONST quantity<cgs::volume>  vc(vs);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::volume>   vs2(vc);
                         
-    quantity<si::energy>    es(1.0*si::joule);      
-    quantity<cgs::energy>   ec(es);
-    quantity<si::energy>    es2(ec);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::energy>   es(1.0*si::joule);      
+    BOOST_CONSTEXPR_OR_CONST quantity<cgs::energy>  ec(es);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::energy>   es2(ec);
                         
-    quantity<si::velocity>  v1 = 2.0*si::meters/si::second,     
-                            v2(2.0*cgs::centimeters/cgs::second);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::velocity> v1 = 2.0*si::meters/si::second,     
+                                                    v2(2.0*cgs::centimeters/cgs::second);
     //]
     
     std::cout << "volume (m^3)  = " << vs << std::endl

--- a/example/conversion_factor.cpp
+++ b/example/conversion_factor.cpp
@@ -50,23 +50,23 @@ int main()
 
     //[conversion_factor_snippet_1
     
-    double dyne_to_newton =
+    BOOST_CONSTEXPR_OR_CONST double dyne_to_newton =
         conversion_factor(cgs::dyne,si::newton);
     std::cout << dyne_to_newton << std::endl;
 
-    double force_over_mass_conversion =
+    BOOST_CONSTEXPR_OR_CONST double force_over_mass_conversion =
         conversion_factor(si::newton/si::kilogram,cgs::dyne/cgs::gram);
     std::cout << force_over_mass_conversion << std::endl;
 
-    double momentum_conversion =
+    BOOST_CONSTEXPR_OR_CONST double momentum_conversion =
         conversion_factor(cgs::momentum(),si::momentum());
     std::cout << momentum_conversion << std::endl;
 
-    double momentum_over_mass_conversion =
+    BOOST_CONSTEXPR_OR_CONST double momentum_over_mass_conversion =
         conversion_factor(si::momentum()/si::mass(),cgs::momentum()/cgs::gram);
     std::cout << momentum_over_mass_conversion << std::endl;
 
-    double acceleration_conversion =
+    BOOST_CONSTEXPR_OR_CONST double acceleration_conversion =
         conversion_factor(cgs::gal,si::meter_per_second_squared);
     std::cout << acceleration_conversion << std::endl;
     

--- a/example/heterogeneous_unit.cpp
+++ b/example/heterogeneous_unit.cpp
@@ -57,8 +57,8 @@ using namespace boost::units;
 int main()
 {
     //[heterogeneous_unit_snippet_1
-    quantity<si::length>        L(1.5*si::meter);
-    quantity<cgs::mass>         M(1.0*cgs::gram);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::length>   L(1.5*si::meter);
+    BOOST_CONSTEXPR_OR_CONST quantity<cgs::mass>    M(1.0*cgs::gram);
     
     std::cout << L << std::endl
               << M << std::endl
@@ -76,7 +76,7 @@ int main()
     //]
     
     //[heterogeneous_unit_snippet_2
-    quantity<si::area>      A(1.5*si::meter*cgs::centimeter);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::area>     A(1.5*si::meter*cgs::centimeter);
     
     std::cout << 1.5*si::meter*cgs::centimeter << std::endl
               << A << std::endl

--- a/example/information.cpp
+++ b/example/information.cpp
@@ -37,6 +37,7 @@ entropy in bytes= 0.125 B
 #include <iostream>
 using std::cout;
 using std::endl;
+using std::log;
 
 #include <boost/units/quantity.hpp>
 #include <boost/units/io.hpp>
@@ -59,6 +60,7 @@ using namespace bu::information;
 // must be a unit of information.  Conversion to the requested return unit is 
 // accomplished automatically by the boost::units library.
 template <typename Sys>
+BOOST_CONSTEXPR
 quantity<bu::unit<bu::information_dimension, Sys> > 
 bernoulli_entropy(double p, const bu::unit<bu::information_dimension, Sys>&) {
     typedef bu::unit<bu::information_dimension, Sys> requested_unit;
@@ -67,15 +69,15 @@ bernoulli_entropy(double p, const bu::unit<bu::information_dimension, Sys>&) {
 
 int main(int argc, char** argv) {
     // a quantity of information (default in units of bytes) 
-    quantity<info> nbytes(1 * si::giga * bit);
+    BOOST_CONSTEXPR_OR_CONST quantity<info> nbytes(1 * si::giga * bit);
     cout << "bytes= " << nbytes << endl;
 
     // a quantity of information, stored as bits
-    quantity<hu::bit::info> nbits(1 * si::mega * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::bit::info> nbits(1 * si::mega * byte);
     cout << "bits= " << nbits << endl;
 
     // a quantity of information, stored as nats
-    quantity<hu::nat::info> nnats(2 * si::kilo * hartleys);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::nat::info> nnats(2 * si::kilo * hartleys);
     cout << "nats= " << nnats << endl;
 
     // how many bytes are in a kibi-byte?

--- a/example/kitchen_sink.cpp
+++ b/example/kitchen_sink.cpp
@@ -200,6 +200,7 @@ namespace units {
 //[kitchen_sink_function_snippet_3
 /// the physical definition of work - computed for an arbitrary unit system 
 template<class System,class Y>
+BOOST_CONSTEXPR
 quantity<unit<energy_dimension,System>,Y> 
 work(quantity<unit<force_dimension,System>,Y> F,
      quantity<unit<length_dimension,System>,Y> dx)
@@ -211,6 +212,7 @@ work(quantity<unit<force_dimension,System>,Y> F,
 //[kitchen_sink_function_snippet_4
 /// the ideal gas law in si units
 template<class Y>
+BOOST_CONSTEXPR
 quantity<si::amount,Y> 
 idealGasLaw(const quantity<si::pressure,Y>& P,
             const quantity<si::volume,Y>& V,
@@ -235,18 +237,18 @@ int main()
     {
     //[kitchen_sink_snippet_1
     /// scalar
-    const double    s1 = 2;
+    BOOST_CONSTEXPR_OR_CONST double     s1 = 2;
     
-    const long                  x1 = 2;
-    const static_rational<4,3>  x2;
+    BOOST_CONSTEXPR_OR_CONST long                   x1 = 2;
+    BOOST_CONSTEXPR_OR_CONST static_rational<4,3>   x2;
     
     /// define some units
-    force       u1 = newton;
-    energy      u2 = joule;
+    BOOST_CONSTEXPR_OR_CONST force      u1 = newton;
+    BOOST_CONSTEXPR_OR_CONST energy     u2 = joule;
     
     /// define some quantities
-    quantity<force>      q1(1.0*u1);
-    quantity<energy>     q2(2.0*u2);
+    BOOST_CONSTEXPR_OR_CONST quantity<force>        q1(1.0*u1);
+    BOOST_CONSTEXPR_OR_CONST quantity<energy>       q2(2.0*u2);
     //]
     
     /// check scalar, unit, and quantity io
@@ -326,8 +328,8 @@ int main()
     
     //[kitchen_sink_snippet_2
     /// check comparison tests
-    quantity<length>    l1(1.0*meter),
-                        l2(2.0*meters);
+    BOOST_CONSTEXPR_OR_CONST quantity<length>   l1(1.0*meter),
+                                                l2(2.0*meters);
     //]
                         
     std::cout << std::boolalpha
@@ -341,22 +343,22 @@ int main()
     
     //[kitchen_sink_snippet_3
     /// check implicit unit conversion from dimensionless to value_type  
-    const double    dimless = (q1/q1);
+    BOOST_CONSTEXPR_OR_CONST double    dimless = (q1/q1);
     //]
     
     std::cout << "dimless = " << dimless << std::endl
               << std::endl;
              
-    quantity<velocity>  v1 = 2.0*meters/second;
+    BOOST_CONSTEXPR_OR_CONST quantity<velocity> v1 = 2.0*meters/second;
         
     std::cout << "v1 = " << v1 << std::endl
               << std::endl;
     
     //[kitchen_sink_snippet_4
     /// test calcuation of work
-    quantity<force>       F(1.0*newton);
-    quantity<length>      dx(1.0*meter);
-    quantity<energy>      E(work(F,dx));
+    BOOST_CONSTEXPR_OR_CONST quantity<force>    F(1.0*newton);
+    BOOST_CONSTEXPR_OR_CONST quantity<length>   dx(1.0*meter);
+    BOOST_CONSTEXPR_OR_CONST quantity<energy>   E(work(F,dx));
     //]
     
     std::cout << "F  = " << F << std::endl
@@ -367,11 +369,11 @@ int main()
     {
     //[kitchen_sink_snippet_5
     /// test ideal gas law
-    quantity<temperature>   T = (273.+37.)*kelvin;
-    quantity<pressure>      P = 1.01325e5*pascals;
-    quantity<length>        r = 0.5e-6*meters;
-    quantity<volume>        V = (4.0/3.0)*3.141592*pow<3>(r);
-    quantity<amount>        n(idealGasLaw(P,V,T));
+    BOOST_CONSTEXPR_OR_CONST quantity<temperature>  T = (273.+37.)*kelvin;
+    BOOST_CONSTEXPR_OR_CONST quantity<pressure>     P = 1.01325e5*pascals;
+    BOOST_CONSTEXPR_OR_CONST quantity<length>       r = 0.5e-6*meters;
+    BOOST_CONSTEXPR_OR_CONST quantity<volume>       V = (4.0/3.0)*3.141592*pow<3>(r);
+    BOOST_CONSTEXPR_OR_CONST quantity<amount>       n(idealGasLaw(P,V,T));
     //]
     
     std::cout << "r = " << r << std::endl
@@ -389,9 +391,9 @@ int main()
     
     //[kitchen_sink_snippet_6
     /// test trig stuff
-    quantity<plane_angle>           theta = 0.375*radians;
-    quantity<dimensionless>         sin_theta = sin(theta);
-    quantity<plane_angle>           thetap = asin(sin_theta);
+    BOOST_CONSTEXPR_OR_CONST quantity<plane_angle>      theta = 0.375*radians;
+    const quantity<dimensionless>                       sin_theta = sin(theta);
+    const quantity<plane_angle>                         thetap = asin(sin_theta);
     //]
     
     std::cout << "theta            = " << theta << std::endl
@@ -413,9 +415,9 @@ int main()
     typedef std::complex<double>    complex_type;
     
     //[kitchen_sink_snippet_7
-    quantity<electric_potential,complex_type> v = complex_type(12.5,0.0)*volts;
-    quantity<current,complex_type>            i = complex_type(3.0,4.0)*amperes;
-    quantity<resistance,complex_type>         z = complex_type(1.5,-2.0)*ohms;
+    BOOST_CONSTEXPR_OR_CONST quantity<electric_potential,complex_type> v = complex_type(12.5,0.0)*volts;
+    BOOST_CONSTEXPR_OR_CONST quantity<current,complex_type>            i = complex_type(3.0,4.0)*amperes;
+    BOOST_CONSTEXPR_OR_CONST quantity<resistance,complex_type>         z = complex_type(1.5,-2.0)*ohms;
     //]
     
     std::cout << "V   = " << v << std::endl
@@ -427,7 +429,7 @@ int main()
     /// check quantities using user-defined type encapsulating error propagation
 
     //[kitchen_sink_snippet_8
-    quantity<length,measurement<double> >
+    BOOST_CONSTEXPR_OR_CONST quantity<length,measurement<double> >
         u(measurement<double>(1.0,0.0)*meters),
         w(measurement<double>(4.52,0.02)*meters),
         x(measurement<double>(2.0,0.2)*meters),

--- a/example/lambda.cpp
+++ b/example/lambda.cpp
@@ -96,9 +96,9 @@ int main(int argc, char **argv) {
    ////////////////////////////////////////////////////////////////////////
 
    // Constants for the current amplitude, frequency, and offset current
-   const bu::quantity<si::current> iamp = 1.5 * si::ampere;
-   const bu::quantity<si::frequency> f = 1.0e3 * si::hertz;
-   const bu::quantity<si::current> i0 = 0.5 * si::ampere;
+   BOOST_CONSTEXPR_OR_CONST bu::quantity<si::current> iamp = 1.5 * si::ampere;
+   BOOST_CONSTEXPR_OR_CONST bu::quantity<si::frequency> f = 1.0e3 * si::hertz;
+   BOOST_CONSTEXPR_OR_CONST bu::quantity<si::current> i0 = 0.5 * si::ampere;
 
    // The invocation of the sin function needs to be postponed using
    // bind to specify the oscillation function. A lengthy static_cast
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
    ////////////////////////////////////////////////////////////////////////
 
    // Length constant
-   const bu::quantity<si::length> l = 1.5 * si::meter;
+   BOOST_CONSTEXPR_OR_CONST bu::quantity<si::length> l = 1.5 * si::meter;
 
    // Again an ugly static_cast is needed to bind pow<2> to the first
    // function argument.
@@ -138,9 +138,9 @@ int main(int argc, char **argv) {
    ////////////////////////////////////////////////////////////////////////
 
    // Absolute temperature constants
-   const bu::quantity<bu::absolute<si::temperature> >
+   BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::absolute<si::temperature> >
        Tref = 273.15 * bu::absolute<si::temperature>();
-   const bu::quantity<bu::absolute<si::temperature> >
+   BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::absolute<si::temperature> >
        Tamb = 300.00 * bu::absolute<si::temperature>();
 
    boost::function<bu::quantity<si::temperature> (bu::quantity<bu::absolute<si::temperature> >,

--- a/example/measurement.hpp
+++ b/example/measurement.hpp
@@ -26,6 +26,7 @@ namespace units {
 namespace sqr_namespace /**/ {
 
 template<class Y>
+BOOST_CONSTEXPR
 Y sqr(Y val)
 { return val*val; }
 
@@ -40,20 +41,20 @@ class measurement
         typedef measurement<Y>                  this_type;
         typedef Y                               value_type;
         
-        measurement(const value_type& val = value_type(),
+        BOOST_CONSTEXPR measurement(const value_type& val = value_type(),
                     const value_type& err = value_type()) : 
             value_(val),
             uncertainty_(std::abs(err)) 
         { }
         
-        measurement(const this_type& source) : 
+        BOOST_CONSTEXPR measurement(const this_type& source) : 
             value_(source.value_),
             uncertainty_(source.uncertainty_) 
         { }
         
         //~measurement() { }
         
-        this_type& operator=(const this_type& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const this_type& source)
         {
             if (this == &source) return *this;
             
@@ -63,43 +64,43 @@ class measurement
             return *this;
         }
         
-        operator value_type() const    { return value_; }
+        BOOST_CONSTEXPR operator value_type() const    { return value_; }
         
-        value_type value() const       { return value_; }
-        value_type uncertainty() const { return uncertainty_; }
-        value_type lower_bound() const { return value_-uncertainty_; }
-        value_type upper_bound() const { return value_+uncertainty_; }
+        BOOST_CONSTEXPR value_type value() const       { return value_; }
+        BOOST_CONSTEXPR value_type uncertainty() const { return uncertainty_; }
+        BOOST_CONSTEXPR value_type lower_bound() const { return value_-uncertainty_; }
+        BOOST_CONSTEXPR value_type upper_bound() const { return value_+uncertainty_; }
         
-        this_type& operator+=(const value_type& val)            
+        BOOST_CXX14_CONSTEXPR this_type& operator+=(const value_type& val)            
         { 
             value_ += val; 
             return *this; 
         }
         
-        this_type& operator-=(const value_type& val)            
+        BOOST_CXX14_CONSTEXPR this_type& operator-=(const value_type& val)            
         { 
             value_ -= val; 
             return *this; 
         }
         
-        this_type& operator*=(const value_type& val)            
+        BOOST_CXX14_CONSTEXPR this_type& operator*=(const value_type& val)            
         { 
             value_ *= val; 
             uncertainty_ *= val; 
             return *this; 
         }
         
-        this_type& operator/=(const value_type& val)            
+        BOOST_CXX14_CONSTEXPR this_type& operator/=(const value_type& val)            
         { 
             value_ /= val; 
             uncertainty_ /= val; 
             return *this; 
         }
         
-        this_type& operator+=(const this_type& /*source*/);
-        this_type& operator-=(const this_type& /*source*/);        
-        this_type& operator*=(const this_type& /*source*/);        
-        this_type& operator/=(const this_type& /*source*/);
+        BOOST_CXX14_CONSTEXPR this_type& operator+=(const this_type& /*source*/);
+        BOOST_CXX14_CONSTEXPR this_type& operator-=(const this_type& /*source*/);        
+        BOOST_CXX14_CONSTEXPR this_type& operator*=(const this_type& /*source*/);        
+        BOOST_CXX14_CONSTEXPR this_type& operator/=(const this_type& /*source*/);
 
     private:
         value_type          value_,
@@ -122,6 +123,7 @@ namespace units {
 
 template<class Y>
 inline
+BOOST_CXX14_CONSTEXPR
 measurement<Y>&
 measurement<Y>::operator+=(const this_type& source)
 {
@@ -133,6 +135,7 @@ measurement<Y>::operator+=(const this_type& source)
 
 template<class Y>
 inline
+BOOST_CXX14_CONSTEXPR
 measurement<Y>&
 measurement<Y>::operator-=(const this_type& source)
 {
@@ -144,6 +147,7 @@ measurement<Y>::operator-=(const this_type& source)
 
 template<class Y>
 inline
+BOOST_CXX14_CONSTEXPR
 measurement<Y>&
 measurement<Y>::operator*=(const this_type& source)
 {
@@ -157,6 +161,7 @@ measurement<Y>::operator*=(const this_type& source)
 
 template<class Y>
 inline
+BOOST_CXX14_CONSTEXPR
 measurement<Y>&
 measurement<Y>::operator/=(const this_type& source)
 {
@@ -171,6 +176,7 @@ measurement<Y>::operator/=(const this_type& source)
 // value_type op measurement
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator+(Y lhs,const measurement<Y>& rhs)
 {
@@ -179,6 +185,7 @@ operator+(Y lhs,const measurement<Y>& rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator-(Y lhs,const measurement<Y>& rhs)
 {
@@ -187,6 +194,7 @@ operator-(Y lhs,const measurement<Y>& rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator*(Y lhs,const measurement<Y>& rhs)
 {
@@ -195,6 +203,7 @@ operator*(Y lhs,const measurement<Y>& rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator/(Y lhs,const measurement<Y>& rhs)
 {
@@ -204,6 +213,7 @@ operator/(Y lhs,const measurement<Y>& rhs)
 // measurement op value_type
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator+(const measurement<Y>& lhs,Y rhs)
 {
@@ -212,6 +222,7 @@ operator+(const measurement<Y>& lhs,Y rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator-(const measurement<Y>& lhs,Y rhs)
 {
@@ -220,6 +231,7 @@ operator-(const measurement<Y>& lhs,Y rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator*(const measurement<Y>& lhs,Y rhs)
 {
@@ -228,6 +240,7 @@ operator*(const measurement<Y>& lhs,Y rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator/(const measurement<Y>& lhs,Y rhs)
 {
@@ -237,6 +250,7 @@ operator/(const measurement<Y>& lhs,Y rhs)
 // measurement op measurement
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator+(const measurement<Y>& lhs,const measurement<Y>& rhs)
 {
@@ -245,6 +259,7 @@ operator+(const measurement<Y>& lhs,const measurement<Y>& rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator-(const measurement<Y>& lhs,const measurement<Y>& rhs)
 {
@@ -253,6 +268,7 @@ operator-(const measurement<Y>& lhs,const measurement<Y>& rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator*(const measurement<Y>& lhs,const measurement<Y>& rhs)
 {
@@ -261,6 +277,7 @@ operator*(const measurement<Y>& lhs,const measurement<Y>& rhs)
 
 template<class Y>
 inline
+BOOST_CONSTEXPR
 measurement<Y>
 operator/(const measurement<Y>& lhs,const measurement<Y>& rhs)
 {
@@ -275,7 +292,7 @@ struct power_typeof_helper<measurement<Y>,static_rational<N,D> >
         typename power_typeof_helper<Y,static_rational<N,D> >::type
     > type; 
     
-    static type value(const measurement<Y>& x)  
+    static BOOST_CXX14_CONSTEXPR type value(const measurement<Y>& x)  
     { 
         const static_rational<N,D>  rat;
 
@@ -295,7 +312,7 @@ struct root_typeof_helper<measurement<Y>,static_rational<N,D> >
         typename root_typeof_helper<Y,static_rational<N,D> >::type
     > type; 
     
-    static type value(const measurement<Y>& x)  
+    static BOOST_CXX14_CONSTEXPR type value(const measurement<Y>& x)  
     { 
         const static_rational<N,D>  rat;
 

--- a/example/non_base_dimension.cpp
+++ b/example/non_base_dimension.cpp
@@ -68,11 +68,11 @@ using namespace boost::units;
 
 int main(void)
 {
-    quantity<imperial_gallon>   ig1(1.0*imperial_gallon());
-    quantity<us_gallon>         ug1(1.0*us_gallon());
+    BOOST_CONSTEXPR_OR_CONST quantity<imperial_gallon>   ig1(1.0*imperial_gallon());
+    BOOST_CONSTEXPR_OR_CONST quantity<us_gallon>         ug1(1.0*us_gallon());
     
-    quantity<imperial_gallon>   ig2(ug1);
-    quantity<us_gallon>         ug2(ig1);
+    BOOST_CONSTEXPR_OR_CONST quantity<imperial_gallon>   ig2(ug1);
+    BOOST_CONSTEXPR_OR_CONST quantity<us_gallon>         ug2(ig1);
     
     return 0;
 }

--- a/example/performance.cpp
+++ b/example/performance.cpp
@@ -176,6 +176,7 @@ void tiled_multiply_carray_outer(T0* first,
 enum { max_value = 1000};
 
 template<class F, class T, class N, class R>
+BOOST_CXX14_CONSTEXPR
 R solve_differential_equation(F f, T lower, T upper, N steps, R start) {
     typedef typename F::template result<T, R>::type f_result;
     T h = (upper - lower) / (1.0*steps);
@@ -197,13 +198,13 @@ using namespace boost::units;
 struct f {
     template<class Arg1, class Arg2> struct result;
     
-    double operator()(const double& x, const double& y) const {
+    BOOST_CONSTEXPR double operator()(const double& x, const double& y) const {
         return(1.0 - x + 4.0 * y);
     }
 
     boost::units::quantity<boost::units::si::velocity>
-    operator()(const quantity<si::time>& x,
-               const quantity<si::length>& y) const {
+    BOOST_CONSTEXPR operator()(const quantity<si::time>& x,
+                               const quantity<si::length>& y) const {
         using namespace boost::units;
         using namespace si;
         return(1.0 * meters / second -
@@ -330,7 +331,7 @@ int main() {
     }
     for(int i = 0; i < max_value; ++i) {
         for(int j = 0; j < max_value; ++j) {
-            double diff =
+            const double diff =
                 std::abs(ublas_result(i,j) - cresult[i * max_value + j]);
             if(diff > ublas_result(i,j) /1e14) {
                 std::cout << std::setprecision(15) << "Uh Oh. ublas_result("
@@ -348,13 +349,13 @@ int main() {
         std::cout << "solving y' = 1 - x + 4 * y with double: ";
         boost::timer timer;
         for(int i = 0; i < 1000; ++i) {
-            double x = .1 * i;
+            const double x = .1 * i;
             values[i] = solve_differential_equation(f(), 0.0, x, i * 100, 1.0);
         }
         std::cout << timer.elapsed() << " seconds" << std::endl;
         for(int i = 0; i < 1000; ++i) {
-            double x = .1 * i;
-            double value = 1.0/4.0 * x - 3.0/16.0 + 19.0/16.0 * std::exp(4 * x);
+            const double x = .1 * i;
+            const double value = 1.0/4.0 * x - 3.0/16.0 + 19.0/16.0 * std::exp(4 * x);
             if(std::abs(values[i] - value) > value / 1e9) {
                 std::cout << std::setprecision(15) << "i = : " << i
                           << ", value = " << value << " approx = "  << values[i]
@@ -370,7 +371,7 @@ int main() {
         std::cout << "solving y' = 1 - x + 4 * y with quantity: ";
         boost::timer timer;
         for(int i = 0; i < 1000; ++i) {
-            quantity<si::time> x = .1 * i * seconds;
+            const quantity<si::time> x = .1 * i * seconds;
             values[i] = solve_differential_equation(
                 f(),
                 0.0 * seconds,
@@ -380,8 +381,8 @@ int main() {
         }
         std::cout << timer.elapsed() << " seconds" << std::endl;
         for(int i = 0; i < 1000; ++i) {
-            double x = .1 * i;
-            quantity<si::length> value =
+            const double x = .1 * i;
+            const quantity<si::length> value =
                 (1.0/4.0 * x - 3.0/16.0 + 19.0/16.0 * std::exp(4 * x)) * meters;
             if(abs(values[i] - value) > value / 1e9) {
                 std::cout << std::setprecision(15) << "i = : " << i

--- a/example/quantity.cpp
+++ b/example/quantity.cpp
@@ -72,8 +72,8 @@ int main(void)
 
     {
     //[quantity_snippet_1
-    quantity<length> L = 2.0*meters;                     // quantity of length
-    quantity<energy> E = kilograms*pow<2>(L/seconds);    // quantity of energy
+    BOOST_CONSTEXPR_OR_CONST quantity<length> L = 2.0*meters;                     // quantity of length
+    BOOST_CONSTEXPR_OR_CONST quantity<energy> E = kilograms*pow<2>(L/seconds);    // quantity of energy
     //]
     
     std::cout << "L                                 = " << L << std::endl
@@ -99,8 +99,8 @@ int main(void)
     
     {
     //[quantity_snippet_2
-    quantity<length,std::complex<double> > L(std::complex<double>(3.0,4.0)*meters);
-    quantity<energy,std::complex<double> > E(kilograms*pow<2>(L/seconds));
+    const quantity<length,std::complex<double> > L(std::complex<double>(3.0,4.0)*meters);
+    const quantity<energy,std::complex<double> > E(kilograms*pow<2>(L/seconds));
     //]
     
     std::cout << "L                                 = " << L << std::endl

--- a/example/radar_beam_height.cpp
+++ b/example/radar_beam_height.cpp
@@ -62,7 +62,7 @@ typedef boost::units::make_system<length_base_unit>::type system;
 /// unit typedefs
 typedef unit<length_dimension,system>    length;
 
-static const length mile,miles;
+BOOST_STATIC_CONSTEXPR length mile,miles;
 
 } // namespace nautical
 
@@ -87,7 +87,7 @@ typedef boost::units::make_system<length_base_unit>::type system;
 /// unit typedefs
 typedef unit<length_dimension,system>    length;
 
-static const length foot,feet;
+BOOST_STATIC_CONSTEXPR length foot,feet;
 
 } // imperial
 
@@ -100,6 +100,7 @@ BOOST_UNITS_DEFINE_CONVERSION_FACTOR(imperial::length_base_unit,
 // radar beam height functions
 //[radar_beam_height_function_snippet_1
 template<class System,typename T>
+BOOST_CONSTEXPR
 quantity<unit<boost::units::length_dimension,System>,T>
 radar_beam_height(const quantity<unit<length_dimension,System>,T>& radar_range,
                   const quantity<unit<length_dimension,System>,T>& earth_radius,
@@ -112,20 +113,20 @@ radar_beam_height(const quantity<unit<length_dimension,System>,T>& radar_range,
 
 //[radar_beam_height_function_snippet_2
 template<class return_type,class System1,class System2,typename T>
+BOOST_CONSTEXPR
 return_type
 radar_beam_height(const quantity<unit<length_dimension,System1>,T>& radar_range,
                   const quantity<unit<length_dimension,System2>,T>& earth_radius,
                   T k = 4.0/3.0)
 {
     // need to decide which system to use for calculation
-    const return_type   rr(radar_range),
-                        er(earth_radius);
-
-    return return_type(pow<2>(rr)/(2.0*k*er));
+    return pow<2>(static_cast<return_type>(radar_range))
+            / (2.0*k*static_cast<return_type>(earth_radius));
 }
 //]
 
 //[radar_beam_height_function_snippet_3
+BOOST_CONSTEXPR
 quantity<imperial::length>
 radar_beam_height(const quantity<nautical::length>& range)
 {
@@ -141,13 +142,13 @@ int main(void)
     using namespace nautical;
 
     //[radar_beam_height_snippet_1
-    const quantity<nautical::length> radar_range(300.0*miles);
-    const quantity<si::length>       earth_radius(6371.0087714*kilo*meters);
-    
-    const quantity<si::length>       beam_height_1(radar_beam_height(quantity<si::length>(radar_range),earth_radius));
-    const quantity<nautical::length> beam_height_2(radar_beam_height(radar_range,quantity<nautical::length>(earth_radius)));
-    const quantity<si::length>       beam_height_3(radar_beam_height< quantity<si::length> >(radar_range,earth_radius));
-    const quantity<nautical::length> beam_height_4(radar_beam_height< quantity<nautical::length> >(radar_range,earth_radius));
+    BOOST_CONSTEXPR_OR_CONST quantity<nautical::length> radar_range(300.0*miles);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::length>       earth_radius(6371.0087714*kilo*meters);
+
+    BOOST_CONSTEXPR_OR_CONST quantity<si::length>       beam_height_1(radar_beam_height(quantity<si::length>(radar_range),earth_radius));
+    BOOST_CONSTEXPR_OR_CONST quantity<nautical::length> beam_height_2(radar_beam_height(radar_range,quantity<nautical::length>(earth_radius)));
+    BOOST_CONSTEXPR_OR_CONST quantity<si::length>       beam_height_3(radar_beam_height< quantity<si::length> >(radar_range,earth_radius));
+    BOOST_CONSTEXPR_OR_CONST quantity<nautical::length> beam_height_4(radar_beam_height< quantity<nautical::length> >(radar_range,earth_radius));
     //]
     
     std::cout << "radar range        : " << radar_range << std::endl

--- a/example/systems.cpp
+++ b/example/systems.cpp
@@ -28,7 +28,7 @@ namespace units {                                                               
 namespace namespace_ {                                                                       \
 typedef make_system<unit_name_ ## _base_unit>::type    unit_name_ ## system_;                \
 typedef unit<dimension_ ## _dimension,unit_name_ ## system_> unit_name_ ## _ ## dimension_;  \
-static const unit_name_ ## _ ## dimension_    unit_name_ ## s;                               \
+BOOST_STATIC_CONSTEXPR unit_name_ ## _ ## dimension_    unit_name_ ## s;                     \
 }                                                                                            \
 }                                                                                            \
 }                                                                                            \
@@ -238,12 +238,12 @@ int main(void)
         
         std::cout << "Testing angle base units..." << std::endl;
         
-        quantity<arcsecond_plane_angle>        as(1.0*arcseconds);
-        quantity<arcminute_plane_angle>        am(1.0*arcminutes);
-        quantity<degree_plane_angle>        d(1.0*degrees);
-        quantity<gradian_plane_angle>        g(1.0*gradians);
-        quantity<radian_plane_angle>        r(1.0*radians);
-        quantity<revolution_plane_angle>    rev(1.0*revolutions);
+        BOOST_CONSTEXPR_OR_CONST quantity<arcsecond_plane_angle>        as(1.0*arcseconds);
+        BOOST_CONSTEXPR_OR_CONST quantity<arcminute_plane_angle>        am(1.0*arcminutes);
+        BOOST_CONSTEXPR_OR_CONST quantity<degree_plane_angle>        d(1.0*degrees);
+        BOOST_CONSTEXPR_OR_CONST quantity<gradian_plane_angle>        g(1.0*gradians);
+        BOOST_CONSTEXPR_OR_CONST quantity<radian_plane_angle>        r(1.0*radians);
+        BOOST_CONSTEXPR_OR_CONST quantity<revolution_plane_angle>    rev(1.0*revolutions);
         
         std::cout << as << " = " << quantity<si::plane_angle>(as) << std::endl
                   << am << " = " << quantity<si::plane_angle>(am) << std::endl
@@ -286,7 +286,7 @@ int main(void)
                   << rev << " = " << quantity<revolution_plane_angle>(rev) << std::endl
                   << std::endl;
                   
-        quantity<steradian_solid_angle>        sa1(1.0*steradians);
+        BOOST_CONSTEXPR_OR_CONST quantity<steradian_solid_angle>        sa1(1.0*steradians);
         
         std::cout << sa1 << std::endl
                   << std::endl;
@@ -297,13 +297,13 @@ int main(void)
 
         std::cout << "Testing astronomical base units..." << std::endl;
         
-        quantity<light_second_length>        ls(1.0*light_seconds);
-        quantity<light_minute_length>        lm(1.0*light_minutes);
-        quantity<astronomical_unit_length>    au(1.0*astronomical_units);
-        quantity<light_hour_length>            lh(1.0*light_hours);
-        quantity<light_day_length>            ld(1.0*light_days);
-        quantity<light_year_length>            ly(1.0*light_years);
-        quantity<parsec_length>                ps(1.0*parsecs);
+        BOOST_CONSTEXPR_OR_CONST quantity<light_second_length>        ls(1.0*light_seconds);
+        BOOST_CONSTEXPR_OR_CONST quantity<light_minute_length>        lm(1.0*light_minutes);
+        BOOST_CONSTEXPR_OR_CONST quantity<astronomical_unit_length>    au(1.0*astronomical_units);
+        BOOST_CONSTEXPR_OR_CONST quantity<light_hour_length>            lh(1.0*light_hours);
+        BOOST_CONSTEXPR_OR_CONST quantity<light_day_length>            ld(1.0*light_days);
+        BOOST_CONSTEXPR_OR_CONST quantity<light_year_length>            ly(1.0*light_years);
+        BOOST_CONSTEXPR_OR_CONST quantity<parsec_length>                ps(1.0*parsecs);
         
         std::cout << ls << " = " << quantity<si::length>(ls) << std::endl
                   << lm << " = " << quantity<si::length>(lm) << std::endl
@@ -363,13 +363,13 @@ int main(void)
         
         std::cout << "Testing imperial base units..." << std::endl;
         
-        quantity<thou_length>            iml1(1.0*thous);
-        quantity<inch_length>            iml2(1.0*inchs);
-        quantity<foot_length>            iml3(1.0*foots);
-        quantity<yard_length>            iml4(1.0*yards);
-        quantity<furlong_length>        iml5(1.0*furlongs);
-        quantity<mile_length>            iml6(1.0*miles);
-        quantity<league_length>            iml7(1.0*leagues);
+        BOOST_CONSTEXPR_OR_CONST quantity<thou_length>            iml1(1.0*thous);
+        BOOST_CONSTEXPR_OR_CONST quantity<inch_length>            iml2(1.0*inchs);
+        BOOST_CONSTEXPR_OR_CONST quantity<foot_length>            iml3(1.0*foots);
+        BOOST_CONSTEXPR_OR_CONST quantity<yard_length>            iml4(1.0*yards);
+        BOOST_CONSTEXPR_OR_CONST quantity<furlong_length>        iml5(1.0*furlongs);
+        BOOST_CONSTEXPR_OR_CONST quantity<mile_length>            iml6(1.0*miles);
+        BOOST_CONSTEXPR_OR_CONST quantity<league_length>            iml7(1.0*leagues);
         
         std::cout << iml1 << " = " << quantity<si::length>(iml1) << std::endl
                   << iml2 << " = " << quantity<si::length>(iml2) << std::endl
@@ -451,14 +451,14 @@ int main(void)
                   << iml7 << " = " << quantity<league_length>(iml7) << std::endl
                   << std::endl;
                   
-        quantity<grain_mass>            imm1(1.0*grains);
-        quantity<drachm_mass>            imm2(1.0*drachms);
-        quantity<ounce_mass>            imm3(1.0*ounces);
-        quantity<pound_mass>            imm4(1.0*pounds);
-        quantity<stone_mass>            imm5(1.0*stones);
-        quantity<quarter_mass>            imm6(1.0*quarters);
-        quantity<hundredweight_mass>    imm7(1.0*hundredweights);
-        quantity<ton_mass>                imm8(1.0*tons);
+        BOOST_CONSTEXPR_OR_CONST quantity<grain_mass>            imm1(1.0*grains);
+        BOOST_CONSTEXPR_OR_CONST quantity<drachm_mass>            imm2(1.0*drachms);
+        BOOST_CONSTEXPR_OR_CONST quantity<ounce_mass>            imm3(1.0*ounces);
+        BOOST_CONSTEXPR_OR_CONST quantity<pound_mass>            imm4(1.0*pounds);
+        BOOST_CONSTEXPR_OR_CONST quantity<stone_mass>            imm5(1.0*stones);
+        BOOST_CONSTEXPR_OR_CONST quantity<quarter_mass>            imm6(1.0*quarters);
+        BOOST_CONSTEXPR_OR_CONST quantity<hundredweight_mass>    imm7(1.0*hundredweights);
+        BOOST_CONSTEXPR_OR_CONST quantity<ton_mass>                imm8(1.0*tons);
 
         std::cout << imm1 << " = " << quantity<si::mass>(imm1) << std::endl
                   << imm2 << " = " << quantity<si::mass>(imm2) << std::endl
@@ -559,11 +559,11 @@ int main(void)
                   << imm8 << " = " << quantity<ton_mass>(imm8) << std::endl
                   << std::endl;
                   
-        quantity<fluid_ounce_volume>    imv1(1.0*fluid_ounces);
-        quantity<gill_volume>            imv2(1.0*gills);
-        quantity<pint_volume>            imv3(1.0*pints);
-        quantity<quart_volume>            imv4(1.0*quarts);
-        quantity<gallon_volume>            imv5(1.0*gallons);
+        BOOST_CONSTEXPR_OR_CONST quantity<fluid_ounce_volume>    imv1(1.0*fluid_ounces);
+        BOOST_CONSTEXPR_OR_CONST quantity<gill_volume>            imv2(1.0*gills);
+        BOOST_CONSTEXPR_OR_CONST quantity<pint_volume>            imv3(1.0*pints);
+        BOOST_CONSTEXPR_OR_CONST quantity<quart_volume>            imv4(1.0*quarts);
+        BOOST_CONSTEXPR_OR_CONST quantity<gallon_volume>            imv5(1.0*gallons);
         
         std::cout << imv1 << " = " << quantity<si::volume>(imv1) << std::endl
                   << imv2 << " = " << quantity<si::volume>(imv2) << std::endl
@@ -619,10 +619,10 @@ int main(void)
         
         std::cout << "Testing metric base units..." << std::endl;
         
-        quantity<fermi_length>            ml1(1.0*fermis);
-        quantity<angstrom_length>        ml2(1.0*angstroms);
-        quantity<micron_length>            ml3(1.0*microns);
-        quantity<nautical_mile_length>    ml4(1.0*nautical_miles);
+        BOOST_CONSTEXPR_OR_CONST quantity<fermi_length>            ml1(1.0*fermis);
+        BOOST_CONSTEXPR_OR_CONST quantity<angstrom_length>        ml2(1.0*angstroms);
+        BOOST_CONSTEXPR_OR_CONST quantity<micron_length>            ml3(1.0*microns);
+        BOOST_CONSTEXPR_OR_CONST quantity<nautical_mile_length>    ml4(1.0*nautical_miles);
     
         std::cout << ml1 << " = " << quantity<si::length>(ml1) << std::endl
                   << ml2 << " = " << quantity<si::length>(ml2) << std::endl
@@ -659,16 +659,16 @@ int main(void)
                   << ml4 << " = " << quantity<nautical_mile_length>(ml4) << std::endl
                   << std::endl;
 
-        quantity<ton_mass>    mm1(1.0*tons);
+        BOOST_CONSTEXPR_OR_CONST quantity<ton_mass>    mm1(1.0*tons);
         
         std::cout << mm1 << " = " << quantity<cgs::mass>(mm1) << std::endl
                   //<< quantity<si::mass>(mm1) << std::endl    // this should work... 
                   << std::endl;
                   
-        quantity<minute_time>    mt1(1.0*minutes);
-        quantity<hour_time>        mt2(1.0*hours);
-        quantity<day_time>        mt3(1.0*days);
-        quantity<year_time>        mt4(1.0*years);
+        BOOST_CONSTEXPR_OR_CONST quantity<minute_time>    mt1(1.0*minutes);
+        BOOST_CONSTEXPR_OR_CONST quantity<hour_time>        mt2(1.0*hours);
+        BOOST_CONSTEXPR_OR_CONST quantity<day_time>        mt3(1.0*days);
+        BOOST_CONSTEXPR_OR_CONST quantity<year_time>        mt4(1.0*years);
         
         std::cout << mt1 << " = " << quantity<si::time>(mt1) << std::endl
                   << mt2 << " = " << quantity<si::time>(mt2) << std::endl
@@ -705,14 +705,14 @@ int main(void)
                   << mt4 << " = " << quantity<year_time>(mt4) << std::endl
                   << std::endl;
                           
-        quantity<knot_velocity>    ms1(1.0*knots);
+        BOOST_CONSTEXPR_OR_CONST quantity<knot_velocity>    ms1(1.0*knots);
         
         std::cout << ms1 << " = " << quantity<si::velocity>(ms1) << std::endl
                   << std::endl;
                   
-        quantity<barn_area>        ma1(1.0*barns);
-        quantity<are_area>        ma2(1.0*ares);
-        quantity<hectare_area>    ma3(1.0*hectares);
+        BOOST_CONSTEXPR_OR_CONST quantity<barn_area>        ma1(1.0*barns);
+        BOOST_CONSTEXPR_OR_CONST quantity<are_area>        ma2(1.0*ares);
+        BOOST_CONSTEXPR_OR_CONST quantity<hectare_area>    ma3(1.0*hectares);
         
         std::cout << ma1 << " = " << quantity<si::area>(ma1) << std::endl
                   << ma2 << " = " << quantity<si::area>(ma2) << std::endl
@@ -738,15 +738,15 @@ int main(void)
                   << ma3 << " = " << quantity<hectare_area>(ma3) << std::endl
                   << std::endl;
         
-        quantity<liter_volume>    mv1(1.0*liters);
+        BOOST_CONSTEXPR_OR_CONST quantity<liter_volume>    mv1(1.0*liters);
         
         std::cout << mv1 << " = " << quantity<si::volume>(mv1) << std::endl
                   << std::endl;
         
-        quantity<mmHg_pressure>            mp1(1.0*mmHgs);
-        quantity<torr_pressure>            mp2(1.0*torrs);
-        quantity<bar_pressure>            mp3(1.0*bars);
-        quantity<atmosphere_pressure>    mp4(1.0*atmospheres);
+        BOOST_CONSTEXPR_OR_CONST quantity<mmHg_pressure>            mp1(1.0*mmHgs);
+        BOOST_CONSTEXPR_OR_CONST quantity<torr_pressure>            mp2(1.0*torrs);
+        BOOST_CONSTEXPR_OR_CONST quantity<bar_pressure>            mp3(1.0*bars);
+        BOOST_CONSTEXPR_OR_CONST quantity<atmosphere_pressure>    mp4(1.0*atmospheres);
         
         std::cout << mp1 << " = " << quantity<si::pressure>(mp1) << std::endl
                   << mp2 << " = " << quantity<si::pressure>(mp2) << std::endl
@@ -789,11 +789,11 @@ int main(void)
         
         std::cout << "Testing U.S. customary base units..." << std::endl;
         
-        quantity<mil_length>            iml1(1.0*mils);
-        quantity<inch_length>            iml2(1.0*inchs);
-        quantity<foot_length>            iml3(1.0*foots);
-        quantity<yard_length>            iml4(1.0*yards);
-        quantity<mile_length>            iml5(1.0*miles);
+        BOOST_CONSTEXPR_OR_CONST quantity<mil_length>            iml1(1.0*mils);
+        BOOST_CONSTEXPR_OR_CONST quantity<inch_length>            iml2(1.0*inchs);
+        BOOST_CONSTEXPR_OR_CONST quantity<foot_length>            iml3(1.0*foots);
+        BOOST_CONSTEXPR_OR_CONST quantity<yard_length>            iml4(1.0*yards);
+        BOOST_CONSTEXPR_OR_CONST quantity<mile_length>            iml5(1.0*miles);
         
         std::cout << iml1 << " = " << quantity<si::length>(iml1) << std::endl
                   << iml2 << " = " << quantity<si::length>(iml2) << std::endl
@@ -843,12 +843,12 @@ int main(void)
                   << iml5 << " = " << quantity<mile_length>(iml5) << std::endl
                   << std::endl;
 
-        quantity<grain_mass>            imm1(1.0*grains);
-        quantity<dram_mass>                imm2(1.0*drams);
-        quantity<ounce_mass>            imm3(1.0*ounces);
-        quantity<pound_mass>            imm4(1.0*pounds);
-        quantity<hundredweight_mass>    imm5(1.0*hundredweights);
-        quantity<ton_mass>                imm6(1.0*tons);
+        BOOST_CONSTEXPR_OR_CONST quantity<grain_mass>            imm1(1.0*grains);
+        BOOST_CONSTEXPR_OR_CONST quantity<dram_mass>                imm2(1.0*drams);
+        BOOST_CONSTEXPR_OR_CONST quantity<ounce_mass>            imm3(1.0*ounces);
+        BOOST_CONSTEXPR_OR_CONST quantity<pound_mass>            imm4(1.0*pounds);
+        BOOST_CONSTEXPR_OR_CONST quantity<hundredweight_mass>    imm5(1.0*hundredweights);
+        BOOST_CONSTEXPR_OR_CONST quantity<ton_mass>                imm6(1.0*tons);
 
         std::cout << imm1 << " = " << quantity<si::mass>(imm1) << std::endl
                   << imm2 << " = " << quantity<si::mass>(imm2) << std::endl
@@ -913,16 +913,16 @@ int main(void)
                   << imm6 << " = " << quantity<ton_mass>(imm6) << std::endl
                   << std::endl;
                   
-        quantity<minim_volume>            imv1(1.0*minims);
-        quantity<fluid_dram_volume>        imv2(1.0*fluid_drams);
-        quantity<teaspoon_volume>        imv3(1.0*teaspoons);
-        quantity<tablespoon_volume>        imv4(1.0*tablespoons);
-        quantity<fluid_ounce_volume>    imv5(1.0*fluid_ounces);
-        quantity<gill_volume>            imv6(1.0*gills);
-        quantity<cup_volume>            imv7(1.0*cups);
-        quantity<pint_volume>            imv8(1.0*pints);
-        quantity<quart_volume>            imv9(1.0*quarts);
-        quantity<gallon_volume>            imv10(1.0*gallons);
+        BOOST_CONSTEXPR_OR_CONST quantity<minim_volume>            imv1(1.0*minims);
+        BOOST_CONSTEXPR_OR_CONST quantity<fluid_dram_volume>        imv2(1.0*fluid_drams);
+        BOOST_CONSTEXPR_OR_CONST quantity<teaspoon_volume>        imv3(1.0*teaspoons);
+        BOOST_CONSTEXPR_OR_CONST quantity<tablespoon_volume>        imv4(1.0*tablespoons);
+        BOOST_CONSTEXPR_OR_CONST quantity<fluid_ounce_volume>    imv5(1.0*fluid_ounces);
+        BOOST_CONSTEXPR_OR_CONST quantity<gill_volume>            imv6(1.0*gills);
+        BOOST_CONSTEXPR_OR_CONST quantity<cup_volume>            imv7(1.0*cups);
+        BOOST_CONSTEXPR_OR_CONST quantity<pint_volume>            imv8(1.0*pints);
+        BOOST_CONSTEXPR_OR_CONST quantity<quart_volume>            imv9(1.0*quarts);
+        BOOST_CONSTEXPR_OR_CONST quantity<gallon_volume>            imv10(1.0*gallons);
         
         std::cout << imv1 << " = " << quantity<si::volume>(imv1) << std::endl
                   << imv2 << " = " << quantity<si::volume>(imv2) << std::endl

--- a/example/temperature.cpp
+++ b/example/temperature.cpp
@@ -70,13 +70,13 @@ BOOST_UNITS_STATIC_CONSTANT(degrees,temperature);
 int main()
 {
     //[temperature_snippet_3
-    quantity<absolute<fahrenheit::temperature> >    T1p(
+    BOOST_CONSTEXPR_OR_CONST quantity<absolute<fahrenheit::temperature> >   T1p(
         32.0*absolute<fahrenheit::temperature>());
-    quantity<fahrenheit::temperature>               T1v(
+    BOOST_CONSTEXPR_OR_CONST quantity<fahrenheit::temperature>              T1v(
         32.0*fahrenheit::degrees);
     
-    quantity<absolute<si::temperature> >            T2p(T1p);
-    quantity<si::temperature>                       T2v(T1v);
+    BOOST_CONSTEXPR_OR_CONST quantity<absolute<si::temperature> >           T2p(T1p);
+    BOOST_CONSTEXPR_OR_CONST quantity<si::temperature>                      T2v(T1v);
     //]
 
     typedef conversion_helper<

--- a/example/tutorial.cpp
+++ b/example/tutorial.cpp
@@ -55,6 +55,7 @@ I*Z == V? true
 using namespace boost::units;
 using namespace boost::units::si;
 
+BOOST_CONSTEXPR
 quantity<energy> 
 work(const quantity<force>& F, const quantity<length>& dx)
 {
@@ -64,9 +65,9 @@ work(const quantity<force>& F, const quantity<length>& dx)
 int main()
 {   
     /// Test calculation of work.
-    quantity<force>     F(2.0 * newton); // Define a quantity of force.
-    quantity<length>    dx(2.0 * meter); // and a distance,
-    quantity<energy>    E(work(F,dx));  // and calculate the work done.
+    BOOST_CONSTEXPR_OR_CONST quantity<force>    F(2.0 * newton); // Define a quantity of force.
+    BOOST_CONSTEXPR_OR_CONST quantity<length>   dx(2.0 * meter); // and a distance,
+    BOOST_CONSTEXPR_OR_CONST quantity<energy>   E(work(F,dx));  // and calculate the work done.
     
     std::cout << "F  = " << F << std::endl
               << "dx = " << dx << std::endl
@@ -77,9 +78,9 @@ int main()
     typedef std::complex<double> complex_type; // double real and imaginary parts.
     
     // Define some complex electrical quantities.
-    quantity<electric_potential, complex_type> v = complex_type(12.5, 0.0) * volts;
-    quantity<current, complex_type>            i = complex_type(3.0, 4.0) * amperes;
-    quantity<resistance, complex_type>         z = complex_type(1.5, -2.0) * ohms;
+    BOOST_CONSTEXPR_OR_CONST quantity<electric_potential, complex_type> v = complex_type(12.5, 0.0) * volts;
+    BOOST_CONSTEXPR_OR_CONST quantity<current, complex_type>            i = complex_type(3.0, 4.0) * amperes;
+    BOOST_CONSTEXPR_OR_CONST quantity<resistance, complex_type>         z = complex_type(1.5, -2.0) * ohms;
     
     std::cout << "V   = " << v << std::endl
               << "I   = " << i << std::endl

--- a/example/unit.cpp
+++ b/example/unit.cpp
@@ -48,11 +48,11 @@ int main()
     using namespace boost::units::test;
 
     //[unit_snippet_1
-    const length                    L;
-    const mass                      M;
+    BOOST_CONSTEXPR_OR_CONST length                     L;
+    BOOST_CONSTEXPR_OR_CONST mass                       M;
     // needs to be namespace-qualified because of global time definition
-    const boost::units::test::time  T;
-    const energy                    E;
+    BOOST_CONSTEXPR_OR_CONST boost::units::test::time   T;
+    BOOST_CONSTEXPR_OR_CONST energy                     E;
     //]
     
     std::cout << "L             = " << L << std::endl

--- a/include/boost/units/absolute.hpp
+++ b/include/boost/units/absolute.hpp
@@ -37,16 +37,16 @@ class absolute
         typedef absolute<Y>     this_type;
         typedef Y               value_type;
         
-        absolute() : val_() { }
-        absolute(const value_type& val) : val_(val) { }
-        absolute(const this_type& source) : val_(source.val_) { }
+        BOOST_CONSTEXPR absolute() : val_() { }
+        BOOST_CONSTEXPR absolute(const value_type& val) : val_(val) { }
+        BOOST_CONSTEXPR absolute(const this_type& source) : val_(source.val_) { }
    
-        this_type& operator=(const this_type& source)           { val_ = source.val_; return *this; }
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const this_type& source)           { val_ = source.val_; return *this; }
         
-        const value_type& value() const                         { return val_; }
+        BOOST_CONSTEXPR const value_type& value() const                         { return val_; }
         
-        const this_type& operator+=(const value_type& val)      { val_ += val; return *this; }
-        const this_type& operator-=(const value_type& val)      { val_ -= val; return *this; }
+        BOOST_CXX14_CONSTEXPR const this_type& operator+=(const value_type& val)      { val_ += val; return *this; }
+        BOOST_CXX14_CONSTEXPR const this_type& operator-=(const value_type& val)      { val_ -= val; return *this; }
         
     private:
         value_type   val_;
@@ -54,42 +54,42 @@ class absolute
 
 /// add a relative value to an absolute one
 template<class Y>
-absolute<Y> operator+(const absolute<Y>& aval,const Y& rval)
+BOOST_CONSTEXPR absolute<Y> operator+(const absolute<Y>& aval,const Y& rval)
 {
     return absolute<Y>(aval.value()+rval);
 }
 
 /// add a relative value to an absolute one
 template<class Y>
-absolute<Y> operator+(const Y& rval,const absolute<Y>& aval)
+BOOST_CONSTEXPR absolute<Y> operator+(const Y& rval,const absolute<Y>& aval)
 {
     return absolute<Y>(aval.value()+rval);
 }
 
 /// subtract a relative value from an absolute one
 template<class Y>
-absolute<Y> operator-(const absolute<Y>& aval,const Y& rval)
+BOOST_CONSTEXPR absolute<Y> operator-(const absolute<Y>& aval,const Y& rval)
 {
     return absolute<Y>(aval.value()-rval);
 }
 
 /// subtracting two absolutes gives a difference
 template<class Y>
-Y operator-(const absolute<Y>& aval1,const absolute<Y>& aval2)
+BOOST_CONSTEXPR Y operator-(const absolute<Y>& aval1,const absolute<Y>& aval2)
 {
     return Y(aval1.value()-aval2.value());
 }
 
 /// creates a quantity from an absolute unit and a raw value
 template<class D, class S, class T>
-quantity<absolute<unit<D, S> >, T> operator*(const T& t, const absolute<unit<D, S> >&)
+BOOST_CONSTEXPR quantity<absolute<unit<D, S> >, T> operator*(const T& t, const absolute<unit<D, S> >&)
 {
     return(quantity<absolute<unit<D, S> >, T>::from_value(t));
 }
 
 /// creates a quantity from an absolute unit and a raw value
 template<class D, class S, class T>
-quantity<absolute<unit<D, S> >, T> operator*(const absolute<unit<D, S> >&, const T& t)
+BOOST_CONSTEXPR quantity<absolute<unit<D, S> >, T> operator*(const absolute<unit<D, S> >&, const T& t)
 {
     return(quantity<absolute<unit<D, S> >, T>::from_value(t));
 }
@@ -138,9 +138,9 @@ namespace units {
         reduce_unit<From::unit_type>::type,                             \
         reduce_unit<To::unit_type>::type>                               \
     {                                                                   \
-        static const bool is_defined = true;                            \
+        BOOST_STATIC_CONSTEXPR bool is_defined = true;                  \
         typedef type_ type;                                             \
-        static type value() { return(value_); }                         \
+        static BOOST_CONSTEXPR type value() { return(value_); }         \
     };                                                                  \
     }                                                                   \
     }                                                                   \

--- a/include/boost/units/base_dimension.hpp
+++ b/include/boost/units/base_dimension.hpp
@@ -83,21 +83,21 @@ class base_dimension :
         /// check_base_dimension will trigger an error earlier
         /// for compilers with less strict name lookup.
         /// INTERNAL ONLY
-        friend Derived* 
+        friend BOOST_CONSTEXPR Derived* 
         check_double_register(const units::base_dimension_ordinal<N>&) 
         { return(0); }
 
         /// Register this ordinal
         /// INTERNAL ONLY
-        friend detail::yes 
+        friend BOOST_CONSTEXPR detail::yes 
         boost_units_is_registered(const units::base_dimension_ordinal<N>&) 
-        { detail::yes result; return(result); }
+        { return(detail::yes()); }
         
         /// But make sure we can identify the current instantiation!
         /// INTERNAL ONLY
-        friend detail::yes 
+        friend BOOST_CONSTEXPR detail::yes 
         boost_units_is_registered(const units::base_dimension_pair<Derived, N>&) 
-        { detail::yes result; return(result); }
+        { return(detail::yes()); }
 };
 
 } // namespace units

--- a/include/boost/units/base_unit.hpp
+++ b/include/boost/units/base_unit.hpp
@@ -104,21 +104,21 @@ class base_unit :
         /// check_base_unit will trigger an error earlier
         /// for compilers with less strict name lookup.
         /// INTERNAL ONLY
-        friend Derived* 
+        friend BOOST_CONSTEXPR Derived* 
         check_double_register(const units::base_unit_ordinal<N>&) 
         { return(0); }
 
         /// Register this ordinal
         /// INTERNAL ONLY
-        friend detail::yes 
+        friend BOOST_CONSTEXPR detail::yes 
         boost_units_unit_is_registered(const units::base_unit_ordinal<N>&) 
-        { detail::yes result; return(result); }
+        { return(detail::yes()); }
         
         /// But make sure we can identify the current instantiation!
         /// INTERNAL ONLY
-        friend detail::yes 
+        friend BOOST_CONSTEXPR detail::yes 
         boost_units_unit_is_registered(const units::base_unit_pair<Derived, N>&) 
-        { detail::yes result; return(result); }
+        { return(detail::yes()); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/angle/arcminute.hpp
+++ b/include/boost/units/base_units/angle/arcminute.hpp
@@ -26,8 +26,8 @@ typedef scaled_base_unit<degree_base_unit, scale<60, static_rational<-1> > >  ar
 
 template<>
 struct base_unit_info<angle::arcminute_base_unit> {
-    static const char* name()   { return("arcminute"); }
-    static const char* symbol() { return("'"); }
+    static BOOST_CONSTEXPR const char* name()   { return("arcminute"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("'"); }
 };
 
 }

--- a/include/boost/units/base_units/angle/arcsecond.hpp
+++ b/include/boost/units/base_units/angle/arcsecond.hpp
@@ -27,8 +27,8 @@ typedef scaled_base_unit<degree_base_unit, scale<3600, static_rational<-1> > >  
 
 template<>
 struct base_unit_info<angle::arcsecond_base_unit> {
-    static const char* name()   { return("arcsecond"); }
-    static const char* symbol() { return("\""); }
+    static BOOST_CONSTEXPR const char* name()   { return("arcsecond"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("\""); }
 };
 
 }

--- a/include/boost/units/base_units/angle/revolution.hpp
+++ b/include/boost/units/base_units/angle/revolution.hpp
@@ -26,8 +26,8 @@ typedef scaled_base_unit<degree_base_unit, scale<360, static_rational<1> > >  re
 
 template<>
 struct base_unit_info<angle::revolution_base_unit> {
-    static const char* name()   { return("revolution"); }
-    static const char* symbol() { return("rev"); }
+    static BOOST_CONSTEXPR const char* name()   { return("revolution"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("rev"); }
 };
 
 }

--- a/include/boost/units/base_units/astronomical/light_day.hpp
+++ b/include/boost/units/base_units/astronomical/light_day.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<boost::units::astronomical::light_second_base_unit, sca
 
 template<>
 struct base_unit_info<astronomical::light_day_base_unit> {
-    static const char* name()   { return("light day"); }
-    static const char* symbol() { return("ldy"); }
+    static BOOST_CONSTEXPR const char* name()   { return("light day"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("ldy"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/astronomical/light_hour.hpp
+++ b/include/boost/units/base_units/astronomical/light_hour.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<boost::units::astronomical::light_second_base_unit, sca
 
 template<>
 struct base_unit_info<astronomical::light_hour_base_unit> {
-    static const char* name()   { return("light hour"); }
-    static const char* symbol() { return("lhr"); }
+    static BOOST_CONSTEXPR const char* name()   { return("light hour"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("lhr"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/astronomical/light_minute.hpp
+++ b/include/boost/units/base_units/astronomical/light_minute.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<boost::units::astronomical::light_second_base_unit, sca
 
 template<>
 struct base_unit_info<astronomical::light_minute_base_unit> {
-    static const char* name()   { return("light minute"); }
-    static const char* symbol() { return("lmn"); }
+    static BOOST_CONSTEXPR const char* name()   { return("light minute"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("lmn"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/astronomical/light_year.hpp
+++ b/include/boost/units/base_units/astronomical/light_year.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<boost::units::astronomical::light_second_base_unit, sca
 
 template<>
 struct base_unit_info<astronomical::light_year_base_unit> {
-    static const char* name()   { return("light year"); }
-    static const char* symbol() { return("ly"); }
+    static BOOST_CONSTEXPR const char* name()   { return("light year"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("ly"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/drachm.hpp
+++ b/include/boost/units/base_units/imperial/drachm.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<16, static_rational<-2> > > drac
 
 template<>
 struct base_unit_info<imperial::drachm_base_unit> {
-    static const char* name()   { return("drachm"); }
-    static const char* symbol() { return("drachm"); }
+    static BOOST_CONSTEXPR const char* name()   { return("drachm"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("drachm"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/fluid_ounce.hpp
+++ b/include/boost/units/base_units/imperial/fluid_ounce.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<20, static_rational<-1> > > fluid
 
 template<>
 struct base_unit_info<imperial::fluid_ounce_base_unit> {
-    static const char* name()   { return("fluid ounce (imp.)"); }
-    static const char* symbol() { return("fl oz"); }
+    static BOOST_CONSTEXPR const char* name()   { return("fluid ounce (imp.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("fl oz"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/foot.hpp
+++ b/include/boost/units/base_units/imperial/foot.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<3, static_rational<-1> > > foot_b
 
 template<>
 struct base_unit_info<imperial::foot_base_unit> {
-    static const char* name()   { return("foot"); }
-    static const char* symbol() { return("ft"); }
+    static BOOST_CONSTEXPR const char* name()   { return("foot"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("ft"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/furlong.hpp
+++ b/include/boost/units/base_units/imperial/furlong.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<220, static_rational<1> > > furlo
 
 template<>
 struct base_unit_info<imperial::furlong_base_unit> {
-    static const char* name()   { return("furlong"); }
-    static const char* symbol() { return("furlong"); }
+    static BOOST_CONSTEXPR const char* name()   { return("furlong"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("furlong"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/gallon.hpp
+++ b/include/boost/units/base_units/imperial/gallon.hpp
@@ -29,8 +29,8 @@ typedef scaled_base_unit<pint_base_unit, scale<8, static_rational<1> > > gallon_
 
 template<>
 struct base_unit_info<imperial::gallon_base_unit> {
-    static const char* name()   { return("gallon (imp.)"); }
-    static const char* symbol() { return("gal"); }
+    static BOOST_CONSTEXPR const char* name()   { return("gallon (imp.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("gal"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/gill.hpp
+++ b/include/boost/units/base_units/imperial/gill.hpp
@@ -29,8 +29,8 @@ typedef scaled_base_unit<pint_base_unit, scale<4, static_rational<-1> > > gill_b
 
 template<>
 struct base_unit_info<imperial::gill_base_unit> {
-    static const char* name()   { return("gill (imp.)"); }
-    static const char* symbol() { return("gill"); }
+    static BOOST_CONSTEXPR const char* name()   { return("gill (imp.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("gill"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/grain.hpp
+++ b/include/boost/units/base_units/imperial/grain.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<7000, static_rational<-1> > > gr
 
 template<>
 struct base_unit_info<imperial::grain_base_unit> {
-    static const char* name()   { return("grain"); }
-    static const char* symbol() { return("grain"); }
+    static BOOST_CONSTEXPR const char* name()   { return("grain"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("grain"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/hundredweight.hpp
+++ b/include/boost/units/base_units/imperial/hundredweight.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<112, static_rational<1> > > hund
 
 template<>
 struct base_unit_info<imperial::hundredweight_base_unit> {
-    static const char* name()   { return("hundredweight"); }
-    static const char* symbol() { return("cwt"); }
+    static BOOST_CONSTEXPR const char* name()   { return("hundredweight"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("cwt"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/inch.hpp
+++ b/include/boost/units/base_units/imperial/inch.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<36, static_rational<-1> > > inch_
 
 template<>
 struct base_unit_info<imperial::inch_base_unit> {
-    static const char* name()   { return("inch"); }
-    static const char* symbol() { return("in"); }
+    static BOOST_CONSTEXPR const char* name()   { return("inch"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("in"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/league.hpp
+++ b/include/boost/units/base_units/imperial/league.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<5280, static_rational<1> > > leag
 
 template<>
 struct base_unit_info<imperial::league_base_unit> {
-    static const char* name()   { return("league"); }
-    static const char* symbol() { return("league"); }
+    static BOOST_CONSTEXPR const char* name()   { return("league"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("league"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/mile.hpp
+++ b/include/boost/units/base_units/imperial/mile.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<1760, static_rational<1> > > mile
 
 template<>
 struct base_unit_info<imperial::mile_base_unit> {
-    static const char* name()   { return("mile"); }
-    static const char* symbol() { return("mi"); }
+    static BOOST_CONSTEXPR const char* name()   { return("mile"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("mi"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/ounce.hpp
+++ b/include/boost/units/base_units/imperial/ounce.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<2, static_rational<-4> > > ounce
 
 template<>
 struct base_unit_info<imperial::ounce_base_unit> {
-    static const char* name()   { return("ounce"); }
-    static const char* symbol() { return("oz"); }
+    static BOOST_CONSTEXPR const char* name()   { return("ounce"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("oz"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/quart.hpp
+++ b/include/boost/units/base_units/imperial/quart.hpp
@@ -29,8 +29,8 @@ typedef scaled_base_unit<pint_base_unit, scale<2, static_rational<1> > > quart_b
 
 template<>
 struct base_unit_info<imperial::quart_base_unit> {
-    static const char* name()   { return("quart (imp.)"); }
-    static const char* symbol() { return("qt"); }
+    static BOOST_CONSTEXPR const char* name()   { return("quart (imp.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("qt"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/quarter.hpp
+++ b/include/boost/units/base_units/imperial/quarter.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<28, static_rational<1> > > quart
 
 template<>
 struct base_unit_info<imperial::quarter_base_unit> {
-    static const char* name()   { return("quarter"); }
-    static const char* symbol() { return("quarter"); }
+    static BOOST_CONSTEXPR const char* name()   { return("quarter"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("quarter"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/stone.hpp
+++ b/include/boost/units/base_units/imperial/stone.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<14, static_rational<1> > > stone
 
 template<>
 struct base_unit_info<imperial::stone_base_unit> {
-    static const char* name()   { return("stone"); }
-    static const char* symbol() { return("st"); }
+    static BOOST_CONSTEXPR const char* name()   { return("stone"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("st"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/thou.hpp
+++ b/include/boost/units/base_units/imperial/thou.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<36000, static_rational<-1> > > th
 
 template<>
 struct base_unit_info<imperial::thou_base_unit> {
-    static const char* name()   { return("thou"); }
-    static const char* symbol() { return("thou"); }
+    static BOOST_CONSTEXPR const char* name()   { return("thou"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("thou"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/imperial/ton.hpp
+++ b/include/boost/units/base_units/imperial/ton.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<2240, static_rational<1> > > ton
 
 template<>
 struct base_unit_info<imperial::ton_base_unit> {
-    static const char* name()   { return("long ton"); }
-    static const char* symbol() { return("t"); }
+    static BOOST_CONSTEXPR const char* name()   { return("long ton"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("t"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/information/byte.hpp
+++ b/include/boost/units/base_units/information/byte.hpp
@@ -26,8 +26,8 @@ typedef scaled_base_unit<boost::units::information::bit_base_unit, scale<2, stat
 
 template<>
 struct base_unit_info<information::byte_base_unit> {
-    static const char* name()   { return("byte"); }
-    static const char* symbol() { return("B"); }
+    static BOOST_CONSTEXPR const char* name()   { return("byte"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("B"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/information/shannon.hpp
+++ b/include/boost/units/base_units/information/shannon.hpp
@@ -26,8 +26,8 @@ typedef scaled_base_unit<boost::units::information::bit_base_unit, scale<1, stat
 
 template<>
 struct base_unit_info<information::shannon_base_unit> {
-    static const char* name()   { return("shannon"); }
-    static const char* symbol() { return("Sh"); }
+    static BOOST_CONSTEXPR const char* name()   { return("shannon"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("Sh"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/metric/angstrom.hpp
+++ b/include/boost/units/base_units/metric/angstrom.hpp
@@ -27,8 +27,8 @@ typedef scaled_base_unit<boost::units::si::meter_base_unit, scale<10, static_rat
 
 template<>
 struct base_unit_info<metric::angstrom_base_unit> {
-    static const char* name()   { return("angstrom"); }
-    static const char* symbol() { return("A"); }
+    static BOOST_CONSTEXPR const char* name()   { return("angstrom"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("A"); }
 };
 
 }

--- a/include/boost/units/base_units/metric/day.hpp
+++ b/include/boost/units/base_units/metric/day.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<boost::units::si::second_base_unit, scale<86400, static
 
 template<>
 struct base_unit_info<metric::day_base_unit> {
-    static const char* name()   { return("day"); }
-    static const char* symbol() { return("d"); }
+    static BOOST_CONSTEXPR const char* name()   { return("day"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("d"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/metric/fermi.hpp
+++ b/include/boost/units/base_units/metric/fermi.hpp
@@ -26,8 +26,8 @@ typedef scaled_base_unit<boost::units::si::meter_base_unit, scale<10, static_rat
 
 template<>
 struct base_unit_info<metric::fermi_base_unit> {
-    static const char* name()   { return("fermi"); }
-    static const char* symbol() { return("fm"); }
+    static BOOST_CONSTEXPR const char* name()   { return("fermi"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("fm"); }
 };
 
 }

--- a/include/boost/units/base_units/metric/hour.hpp
+++ b/include/boost/units/base_units/metric/hour.hpp
@@ -27,8 +27,8 @@ typedef scaled_base_unit<boost::units::si::second_base_unit, scale<60, static_ra
 
 template<>
 struct base_unit_info<metric::hour_base_unit> {
-    static const char* name()   { return("hour"); }
-    static const char* symbol() { return("h"); }
+    static BOOST_CONSTEXPR const char* name()   { return("hour"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("h"); }
 };
 
 }

--- a/include/boost/units/base_units/metric/micron.hpp
+++ b/include/boost/units/base_units/metric/micron.hpp
@@ -26,8 +26,8 @@ typedef scaled_base_unit<boost::units::si::meter_base_unit, scale<10, static_rat
 
 template<>
 struct base_unit_info<metric::micron_base_unit> {
-    static const char* name()   { return("micron"); }
-    static const char* symbol() { return("u"); }
+    static BOOST_CONSTEXPR const char* name()   { return("micron"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("u"); }
 };
 
 }

--- a/include/boost/units/base_units/metric/minute.hpp
+++ b/include/boost/units/base_units/metric/minute.hpp
@@ -27,8 +27,8 @@ typedef scaled_base_unit<boost::units::si::second_base_unit, scale<60, static_ra
 
 template<>
 struct base_unit_info<metric::minute_base_unit> {
-    static const char* name()   { return("minute"); }
-    static const char* symbol() { return("min"); }
+    static BOOST_CONSTEXPR const char* name()   { return("minute"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("min"); }
 };
 
 }

--- a/include/boost/units/base_units/metric/nautical_mile.hpp
+++ b/include/boost/units/base_units/metric/nautical_mile.hpp
@@ -26,8 +26,8 @@ typedef scaled_base_unit<boost::units::si::meter_base_unit, scale<1852, static_r
 
 template<>
 struct base_unit_info<metric::nautical_mile_base_unit> {
-    static const char* name()   { return("nautical mile"); }
-    static const char* symbol() { return("nmi"); }
+    static BOOST_CONSTEXPR const char* name()   { return("nautical mile"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("nmi"); }
 };
 
 }

--- a/include/boost/units/base_units/metric/ton.hpp
+++ b/include/boost/units/base_units/metric/ton.hpp
@@ -29,8 +29,8 @@ typedef scaled_base_unit<boost::units::si::kilogram_base_unit, scale<1000, stati
 
 template<>
 struct base_unit_info<metric::ton_base_unit> {
-    static const char* name()   { return("metric ton"); }
-    static const char* symbol() { return("t"); }
+    static BOOST_CONSTEXPR const char* name()   { return("metric ton"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("t"); }
 };
 
 }

--- a/include/boost/units/base_units/metric/year.hpp
+++ b/include/boost/units/base_units/metric/year.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<boost::units::si::second_base_unit, scale<31557600, sta
 
 template<>
 struct base_unit_info<metric::year_base_unit> {
-    static const char* name()   { return("Julian year"); }
-    static const char* symbol() { return("yr"); }
+    static BOOST_CONSTEXPR const char* name()   { return("Julian year"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("yr"); }
 };
 
 }

--- a/include/boost/units/base_units/us/cup.hpp
+++ b/include/boost/units/base_units/us/cup.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<2, static_rational<-1> > > cup_ba
 
 template<>
 struct base_unit_info<us::cup_base_unit> {
-    static const char* name()   { return("cup"); }
-    static const char* symbol() { return("c"); }
+    static BOOST_CONSTEXPR const char* name()   { return("cup"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("c"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/dram.hpp
+++ b/include/boost/units/base_units/us/dram.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<16, static_rational<-2> > > dram
 
 template<>
 struct base_unit_info<us::dram_base_unit> {
-    static const char* name()   { return("dram (U.S.)"); }
-    static const char* symbol() { return("dr"); }
+    static BOOST_CONSTEXPR const char* name()   { return("dram (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("dr"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/fluid_dram.hpp
+++ b/include/boost/units/base_units/us/fluid_dram.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<2, static_rational<-7> > > fluid_
 
 template<>
 struct base_unit_info<us::fluid_dram_base_unit> {
-    static const char* name()   { return("fluid dram (U.S.)"); }
-    static const char* symbol() { return("fl dr"); }
+    static BOOST_CONSTEXPR const char* name()   { return("fluid dram (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("fl dr"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/fluid_ounce.hpp
+++ b/include/boost/units/base_units/us/fluid_ounce.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<16, static_rational<-1> > > fluid
 
 template<>
 struct base_unit_info<us::fluid_ounce_base_unit> {
-    static const char* name()   { return("fluid ounce (U.S.)"); }
-    static const char* symbol() { return("fl oz"); }
+    static BOOST_CONSTEXPR const char* name()   { return("fluid ounce (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("fl oz"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/foot.hpp
+++ b/include/boost/units/base_units/us/foot.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<3, static_rational<-1> > > foot_b
 
 template<>
 struct base_unit_info<us::foot_base_unit> {
-    static const char* name()   { return("foot"); }
-    static const char* symbol() { return("ft"); }
+    static BOOST_CONSTEXPR const char* name()   { return("foot"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("ft"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/gallon.hpp
+++ b/include/boost/units/base_units/us/gallon.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<2, static_rational<3> > > gallon_
 
 template<>
 struct base_unit_info<us::gallon_base_unit> {
-    static const char* name()   { return("gallon (U.S.)"); }
-    static const char* symbol() { return("gal"); }
+    static BOOST_CONSTEXPR const char* name()   { return("gallon (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("gal"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/gill.hpp
+++ b/include/boost/units/base_units/us/gill.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<2, static_rational<-2> > > gill_b
 
 template<>
 struct base_unit_info<us::gill_base_unit> {
-    static const char* name()   { return("gill (U.S.)"); }
-    static const char* symbol() { return("gi"); }
+    static BOOST_CONSTEXPR const char* name()   { return("gill (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("gi"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/grain.hpp
+++ b/include/boost/units/base_units/us/grain.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<7000, static_rational<-1> > > gr
 
 template<>
 struct base_unit_info<us::grain_base_unit> {
-    static const char* name()   { return("grain"); }
-    static const char* symbol() { return("gr"); }
+    static BOOST_CONSTEXPR const char* name()   { return("grain"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("gr"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/hundredweight.hpp
+++ b/include/boost/units/base_units/us/hundredweight.hpp
@@ -29,8 +29,8 @@ typedef scaled_base_unit<pound_base_unit, scale<100, static_rational<1> > > hund
 
 template<>
 struct base_unit_info<us::hundredweight_base_unit> {
-    static const char* name()   { return("hundredweight (U.S.)"); }
-    static const char* symbol() { return("cwt"); }
+    static BOOST_CONSTEXPR const char* name()   { return("hundredweight (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("cwt"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/inch.hpp
+++ b/include/boost/units/base_units/us/inch.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<36, static_rational<-1> > > inch_
 
 template<>
 struct base_unit_info<us::inch_base_unit> {
-    static const char* name()   { return("inch"); }
-    static const char* symbol() { return("in"); }
+    static BOOST_CONSTEXPR const char* name()   { return("inch"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("in"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/mil.hpp
+++ b/include/boost/units/base_units/us/mil.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<36000, static_rational<-1> > > mi
 
 template<>
 struct base_unit_info<us::mil_base_unit> {
-    static const char* name()   { return("mil"); }
-    static const char* symbol() { return("mil"); }
+    static BOOST_CONSTEXPR const char* name()   { return("mil"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("mil"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/mile.hpp
+++ b/include/boost/units/base_units/us/mile.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<yard_base_unit, scale<1760, static_rational<1> > > mile
 
 template<>
 struct base_unit_info<us::mile_base_unit> {
-    static const char* name()   { return("mile"); }
-    static const char* symbol() { return("mi"); }
+    static BOOST_CONSTEXPR const char* name()   { return("mile"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("mi"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/minim.hpp
+++ b/include/boost/units/base_units/us/minim.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<7680, static_rational<-1> > > min
 
 template<>
 struct base_unit_info<us::minim_base_unit> {
-    static const char* name()   { return("minim (U.S.)"); }
-    static const char* symbol() { return("minim"); }
+    static BOOST_CONSTEXPR const char* name()   { return("minim (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("minim"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/ounce.hpp
+++ b/include/boost/units/base_units/us/ounce.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<2, static_rational<-4> > > ounce
 
 template<>
 struct base_unit_info<us::ounce_base_unit> {
-    static const char* name()   { return("ounce"); }
-    static const char* symbol() { return("oz"); }
+    static BOOST_CONSTEXPR const char* name()   { return("ounce"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("oz"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/quart.hpp
+++ b/include/boost/units/base_units/us/quart.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<2, static_rational<1> > > quart_b
 
 template<>
 struct base_unit_info<us::quart_base_unit> {
-    static const char* name()   { return("quart (U.S.)"); }
-    static const char* symbol() { return("qt"); }
+    static BOOST_CONSTEXPR const char* name()   { return("quart (U.S.)"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("qt"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/tablespoon.hpp
+++ b/include/boost/units/base_units/us/tablespoon.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<2, static_rational<-5> > > tables
 
 template<>
 struct base_unit_info<us::tablespoon_base_unit> {
-    static const char* name()   { return("tablespoon"); }
-    static const char* symbol() { return("tbsp"); }
+    static BOOST_CONSTEXPR const char* name()   { return("tablespoon"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("tbsp"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/teaspoon.hpp
+++ b/include/boost/units/base_units/us/teaspoon.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pint_base_unit, scale<96, static_rational<-1> > > teasp
 
 template<>
 struct base_unit_info<us::teaspoon_base_unit> {
-    static const char* name()   { return("teaspoon"); }
-    static const char* symbol() { return("tsp"); }
+    static BOOST_CONSTEXPR const char* name()   { return("teaspoon"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("tsp"); }
 };
 
 } // namespace units

--- a/include/boost/units/base_units/us/ton.hpp
+++ b/include/boost/units/base_units/us/ton.hpp
@@ -28,8 +28,8 @@ typedef scaled_base_unit<pound_base_unit, scale<2000, static_rational<1> > > ton
 
 template<>
 struct base_unit_info<us::ton_base_unit> {
-    static const char* name()   { return("short ton"); }
-    static const char* symbol() { return("t"); }
+    static BOOST_CONSTEXPR const char* name()   { return("short ton"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("t"); }
 };
 
 } // namespace units

--- a/include/boost/units/cmath.hpp
+++ b/include/boost/units/cmath.hpp
@@ -47,6 +47,7 @@ namespace units {
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 isfinite BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 { 
@@ -56,6 +57,7 @@ isfinite BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 isinf BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 { 
@@ -65,6 +67,7 @@ isinf BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline
+BOOST_CONSTEXPR
 bool 
 isnan BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 { 
@@ -74,6 +77,7 @@ isnan BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 isnormal BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 { 
@@ -83,6 +87,7 @@ isnormal BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 isgreater BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                             const quantity<Unit,Y>& q2)
@@ -93,6 +98,7 @@ isgreater BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 isgreaterequal BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                                  const quantity<Unit,Y>& q2)
@@ -103,6 +109,7 @@ isgreaterequal BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 isless BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                          const quantity<Unit,Y>& q2)
@@ -113,6 +120,7 @@ isless BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 islessequal BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                               const quantity<Unit,Y>& q2)
@@ -123,6 +131,7 @@ islessequal BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 islessgreater BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                                 const quantity<Unit,Y>& q2)
@@ -133,6 +142,7 @@ islessgreater BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 bool 
 isunordered BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                               const quantity<Unit,Y>& q2)
@@ -143,6 +153,7 @@ isunordered BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 abs BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -155,6 +166,7 @@ abs BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 ceil BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -167,6 +179,7 @@ ceil BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 copysign BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
          const quantity<Unit,Y>& q2)
@@ -180,6 +193,7 @@ copysign BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 fabs BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -192,6 +206,7 @@ fabs BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 floor BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -204,6 +219,7 @@ floor BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 fdim BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                        const quantity<Unit,Y>& q2)
@@ -219,6 +235,7 @@ fdim BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit1,class Unit2,class Unit3,class Y>
 inline 
+BOOST_CONSTEXPR
 typename add_typeof_helper<
     typename multiply_typeof_helper<quantity<Unit1,Y>,
                                     quantity<Unit2,Y> >::type,
@@ -243,6 +260,7 @@ fma BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit1,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 fmax BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                        const quantity<Unit,Y>& q2)
@@ -256,6 +274,7 @@ fmax BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 fmin BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                        const quantity<Unit,Y>& q2)
@@ -269,6 +288,7 @@ fmin BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 int 
 fpclassify BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 { 
@@ -279,6 +299,7 @@ fpclassify BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 typename root_typeof_helper<
     typename add_typeof_helper<
         typename power_typeof_helper<quantity<Unit,Y>,
@@ -302,6 +323,7 @@ hypot BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,const quantit
 // does ISO C++ support long long? g++ claims not
 //template<class Unit,class Y>
 //inline 
+//BOOST_CONSTEXPR
 //quantity<Unit,long long> 
 //llrint BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 //{
@@ -315,6 +337,7 @@ hypot BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,const quantit
 // does ISO C++ support long long? g++ claims not
 //template<class Unit,class Y>
 //inline 
+//BOOST_CONSTEXPR
 //quantity<Unit,long long> 
 //llround BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 //{
@@ -329,6 +352,7 @@ hypot BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,const quantit
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 nearbyint BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -343,6 +367,7 @@ nearbyint BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> nextafter BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                                              const quantity<Unit,Y>& q2)
 {
@@ -354,6 +379,7 @@ quantity<Unit,Y> nextafter BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit
 }
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q1,
                                                               const quantity<Unit,Y>& q2)
 {
@@ -371,6 +397,7 @@ quantity<Unit,Y> nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Uni
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 rint BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -385,6 +412,7 @@ rint BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 round BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -397,6 +425,7 @@ round BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 int 
 signbit BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 { 
@@ -407,6 +436,7 @@ signbit BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 quantity<Unit,Y> 
 trunc BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 {
@@ -419,6 +449,7 @@ trunc BOOST_PREVENT_MACRO_SUBSTITUTION (const quantity<Unit,Y>& q)
 
 template<class Unit,class Y>
 inline
+BOOST_CONSTEXPR
 quantity<Unit, Y>
 fmod(const quantity<Unit,Y>& q1, const quantity<Unit,Y>& q2)
 {
@@ -431,6 +462,7 @@ fmod(const quantity<Unit,Y>& q1, const quantity<Unit,Y>& q2)
 
 template<class Unit, class Y>
 inline
+BOOST_CONSTEXPR
 quantity<Unit, Y>
 modf(const quantity<Unit, Y>& q1, quantity<Unit, Y>* q2)
 {
@@ -443,6 +475,7 @@ modf(const quantity<Unit, Y>& q1, quantity<Unit, Y>* q2)
 
 template<class Unit, class Y, class Int>
 inline
+BOOST_CONSTEXPR
 quantity<Unit, Y>
 frexp(const quantity<Unit, Y>& q,Int* ex)
 {
@@ -457,6 +490,7 @@ frexp(const quantity<Unit, Y>& q,Int* ex)
 /// and roots can be computed by @c pow<Ex> and @c root<Rt> respectively.
 template<class S, class Y>
 inline
+BOOST_CONSTEXPR
 quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>
 pow(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q1,
     const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q2)
@@ -470,6 +504,7 @@ pow(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q1,
 
 template<class S, class Y>
 inline
+BOOST_CONSTEXPR
 quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>
 exp(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q)
 {
@@ -482,6 +517,7 @@ exp(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q)
 
 template<class Unit, class Y, class Int>
 inline
+BOOST_CONSTEXPR
 quantity<Unit, Y>
 ldexp(const quantity<Unit, Y>& q,const Int& ex)
 {
@@ -494,6 +530,7 @@ ldexp(const quantity<Unit, Y>& q,const Int& ex)
 
 template<class S, class Y>
 inline
+BOOST_CONSTEXPR
 quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>
 log(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q)
 {
@@ -506,6 +543,7 @@ log(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q)
 
 template<class S, class Y>
 inline
+BOOST_CONSTEXPR
 quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>
 log10(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q)
 {
@@ -518,6 +556,7 @@ log10(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(S), Y>& q)
 
 template<class Unit,class Y>
 inline 
+BOOST_CONSTEXPR
 typename root_typeof_helper<
                             quantity<Unit,Y>,
                             static_rational<2>
@@ -546,6 +585,7 @@ namespace units {
 
 /// cos of theta in radians
 template<class Y>
+BOOST_CONSTEXPR
 typename dimensionless_quantity<si::system,Y>::type 
 cos(const quantity<si::plane_angle,Y>& theta)
 {
@@ -555,6 +595,7 @@ cos(const quantity<si::plane_angle,Y>& theta)
 
 /// sin of theta in radians
 template<class Y>
+BOOST_CONSTEXPR
 typename dimensionless_quantity<si::system,Y>::type 
 sin(const quantity<si::plane_angle,Y>& theta)
 {
@@ -564,6 +605,7 @@ sin(const quantity<si::plane_angle,Y>& theta)
 
 /// tan of theta in radians
 template<class Y>
+BOOST_CONSTEXPR
 typename dimensionless_quantity<si::system,Y>::type 
 tan(const quantity<si::plane_angle,Y>& theta)
 {
@@ -573,6 +615,7 @@ tan(const quantity<si::plane_angle,Y>& theta)
 
 /// cos of theta in other angular units 
 template<class System,class Y>
+BOOST_CONSTEXPR
 typename dimensionless_quantity<System,Y>::type 
 cos(const quantity<unit<plane_angle_dimension,System>,Y>& theta)
 {
@@ -581,6 +624,7 @@ cos(const quantity<unit<plane_angle_dimension,System>,Y>& theta)
 
 /// sin of theta in other angular units 
 template<class System,class Y>
+BOOST_CONSTEXPR
 typename dimensionless_quantity<System,Y>::type 
 sin(const quantity<unit<plane_angle_dimension,System>,Y>& theta)
 {
@@ -589,6 +633,7 @@ sin(const quantity<unit<plane_angle_dimension,System>,Y>& theta)
 
 /// tan of theta in other angular units 
 template<class System,class Y>
+BOOST_CONSTEXPR
 typename dimensionless_quantity<System,Y>::type 
 tan(const quantity<unit<plane_angle_dimension,System>,Y>& theta)
 {
@@ -597,6 +642,7 @@ tan(const quantity<unit<plane_angle_dimension,System>,Y>& theta)
 
 /// acos of dimensionless quantity returning angle in same system
 template<class Y,class System>
+BOOST_CONSTEXPR
 quantity<unit<plane_angle_dimension, homogeneous_system<System> >,Y>
 acos(const quantity<unit<dimensionless_type, homogeneous_system<System> >,Y>& val)
 {
@@ -606,6 +652,7 @@ acos(const quantity<unit<dimensionless_type, homogeneous_system<System> >,Y>& va
 
 /// acos of dimensionless quantity returning angle in radians
 template<class Y>
+BOOST_CONSTEXPR
 quantity<angle::radian_base_unit::unit_type,Y>
 acos(const quantity<unit<dimensionless_type, heterogeneous_dimensionless_system>,Y>& val)
 {
@@ -615,6 +662,7 @@ acos(const quantity<unit<dimensionless_type, heterogeneous_dimensionless_system>
 
 /// asin of dimensionless quantity returning angle in same system
 template<class Y,class System>
+BOOST_CONSTEXPR
 quantity<unit<plane_angle_dimension, homogeneous_system<System> >,Y>
 asin(const quantity<unit<dimensionless_type, homogeneous_system<System> >,Y>& val)
 {
@@ -624,6 +672,7 @@ asin(const quantity<unit<dimensionless_type, homogeneous_system<System> >,Y>& va
 
 /// asin of dimensionless quantity returning angle in radians
 template<class Y>
+BOOST_CONSTEXPR
 quantity<angle::radian_base_unit::unit_type,Y>
 asin(const quantity<unit<dimensionless_type, heterogeneous_dimensionless_system>,Y>& val)
 {
@@ -633,6 +682,7 @@ asin(const quantity<unit<dimensionless_type, heterogeneous_dimensionless_system>
 
 /// atan of dimensionless quantity returning angle in same system
 template<class Y,class System>
+BOOST_CONSTEXPR
 quantity<unit<plane_angle_dimension, homogeneous_system<System> >,Y>
 atan(const quantity<unit<dimensionless_type, homogeneous_system<System> >, Y>& val)
 {
@@ -642,6 +692,7 @@ atan(const quantity<unit<dimensionless_type, homogeneous_system<System> >, Y>& v
 
 /// atan of dimensionless quantity returning angle in radians
 template<class Y>
+BOOST_CONSTEXPR
 quantity<angle::radian_base_unit::unit_type,Y>
 atan(const quantity<unit<dimensionless_type, heterogeneous_dimensionless_system>, Y>& val)
 {
@@ -651,6 +702,7 @@ atan(const quantity<unit<dimensionless_type, heterogeneous_dimensionless_system>
 
 /// atan2 of @c value_type returning angle in radians
 template<class Y, class Dimension, class System>
+BOOST_CONSTEXPR
 quantity<unit<plane_angle_dimension, homogeneous_system<System> >, Y>
 atan2(const quantity<unit<Dimension, homogeneous_system<System> >, Y>& y,
       const quantity<unit<Dimension, homogeneous_system<System> >, Y>& x)
@@ -661,6 +713,7 @@ atan2(const quantity<unit<Dimension, homogeneous_system<System> >, Y>& y,
 
 /// atan2 of @c value_type returning angle in radians
 template<class Y, class Dimension, class System>
+BOOST_CONSTEXPR
 quantity<angle::radian_base_unit::unit_type,Y>
 atan2(const quantity<unit<Dimension, heterogeneous_system<System> >, Y>& y,
       const quantity<unit<Dimension, heterogeneous_system<System> >, Y>& x)

--- a/include/boost/units/config.hpp
+++ b/include/boost/units/config.hpp
@@ -75,7 +75,7 @@
     #define BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(a, b) BOOST_STATIC_ASSERT((sizeof(a) == sizeof(b)))
 #else
     ///INTERNAL ONLY
-    #define BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(a, b) ((void)0)
+    #define BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(a, b)
 #endif
 
 #ifdef BOOST_UNITS_DOXYGEN

--- a/include/boost/units/conversion.hpp
+++ b/include/boost/units/conversion.hpp
@@ -51,7 +51,7 @@ struct conversion_helper;
 template<class From, class To>
 struct conversion_helper
 {
-    static To convert(const From&);
+    static BOOST_CONSTEXPR To convert(const From&);
 };
 
 #endif
@@ -77,9 +77,9 @@ struct conversion_helper
     template<>                                                              \
     struct base_unit_converter<Source, reduce_unit<Destination::unit_type>::type>   \
     {                                                                       \
-        static const bool is_defined = true;                                \
+        BOOST_STATIC_CONSTEXPR bool is_defined = true;                      \
         typedef type_ type;                                                 \
-        static type value() { return(value_); }                             \
+        static BOOST_CONSTEXPR type value() { return(value_); }             \
     };                                                                      \
     }                                                                       \
     }                                                                       \
@@ -103,9 +103,9 @@ struct conversion_helper
         BOOST_UNITS_MAKE_HETEROGENEOUS_UNIT(Destination, typename Source::dimension_type)\
     >                                                                       \
     {                                                                       \
-        static const bool is_defined = true;                                \
+        BOOST_STATIC_CONSTEXPR bool is_defined = true;                      \
         typedef type_ type;                                                 \
-        static type value() { return(value_); }                             \
+        static BOOST_CONSTEXPR type value() { return(value_); }             \
     };                                                                      \
     }                                                                       \
     }                                                                       \
@@ -121,7 +121,7 @@ struct conversion_helper
     template<>                                                      \
     struct unscaled_get_default_conversion<unscale<Source>::type>   \
     {                                                               \
-        static const bool is_defined = true;                        \
+        BOOST_STATIC_CONSTEXPR bool is_defined = true;              \
         typedef Dest::unit_type type;                               \
     };                                                              \
     }                                                               \
@@ -140,7 +140,7 @@ struct conversion_helper
     template<BOOST_PP_SEQ_ENUM(Params)>                                 \
     struct unscaled_get_default_conversion<Source>                      \
     {                                                                   \
-        static const bool is_defined = true;                            \
+        BOOST_STATIC_CONSTEXPR bool is_defined = true;                  \
         typedef typename Dest::unit_type type;                          \
     };                                                                  \
     }                                                                   \
@@ -170,6 +170,7 @@ BOOST_UNITS_DEFAULT_CONVERSION(namespace_::name_ ## _base_unit, unit)
 /// Find the conversion factor between two units.
 template<class FromUnit,class ToUnit>
 inline
+BOOST_CONSTEXPR
 typename one_to_double_type<
     typename detail::conversion_factor_helper<FromUnit, ToUnit>::type
 >::type

--- a/include/boost/units/conversion.hpp
+++ b/include/boost/units/conversion.hpp
@@ -158,8 +158,8 @@ namespace units {                                                           \
 namespace namespace_ {                                                      \
 struct name_ ## _base_unit                                                  \
   : base_unit<name_ ## _base_unit, unit::dimension_type, id> {              \
-    static const char* name() { return(name_string_); }                     \
-    static const char* symbol() { return(symbol_string_); }                 \
+    static BOOST_CONSTEXPR const char* name() { return(name_string_); }     \
+    static BOOST_CONSTEXPR const char* symbol() { return(symbol_string_); } \
 };                                                                          \
 }                                                                           \
 }                                                                           \

--- a/include/boost/units/detail/absolute_impl.hpp
+++ b/include/boost/units/detail/absolute_impl.hpp
@@ -32,7 +32,7 @@ struct reduce_unit<absolute<unit<D, S> > >
 namespace detail {
 
 struct undefined_affine_conversion_base {
-    static const bool is_defined = false;
+    BOOST_STATIC_CONSTEXPR bool is_defined = false;
 };
 
 } // namespace detail
@@ -51,7 +51,7 @@ struct affine_conversion_impl<true, ReverseIsDefined>
 {
     template<class Unit1, class Unit2, class T0, class T1>
     struct apply {
-        static T1 value(const T0& t0)
+        static BOOST_CONSTEXPR T1 value(const T0& t0)
         {
             return(
                 t0 * 
@@ -67,7 +67,7 @@ struct affine_conversion_impl<false, true>
     template<class Unit1, class Unit2, class T0, class T1>
     struct apply
     {
-        static T1 value(const T0& t0)
+        static BOOST_CONSTEXPR T1 value(const T0& t0)
         {
             return(
                 (t0 - affine_conversion_helper<typename reduce_unit<Unit2>::type, typename reduce_unit<Unit1>::type>::value()) * 
@@ -84,7 +84,7 @@ struct conversion_helper<quantity<absolute<Unit1>, T1>, quantity<absolute<Unit2>
 {
     typedef quantity<absolute<Unit1>, T1> from_quantity_type;
     typedef quantity<absolute<Unit2>, T2> to_quantity_type;
-    static to_quantity_type convert(const from_quantity_type& source)
+    static BOOST_CONSTEXPR to_quantity_type convert(const from_quantity_type& source)
     {
         return(
             to_quantity_type::from_value(

--- a/include/boost/units/detail/conversion_impl.hpp
+++ b/include/boost/units/detail/conversion_impl.hpp
@@ -46,12 +46,12 @@ struct call_base_unit_converter;
 
 /// INTERNAL ONLY
 struct undefined_base_unit_converter_base {
-    static const bool is_defined = false;
+    BOOST_STATIC_CONSTEXPR bool is_defined = false;
 };
 
 /// INTERNAL ONLY
 struct no_default_conversion {
-    static const bool is_defined = false;
+    BOOST_STATIC_CONSTEXPR bool is_defined = false;
 };
 
 /// INTERNAL ONLY
@@ -110,11 +110,10 @@ struct base_unit_converter_base : undefined_base_unit_converter_base {
 template<class Source>
 struct base_unit_converter_base<Source, BOOST_UNITS_MAKE_HETEROGENEOUS_UNIT(Source, typename Source::dimension_type)>
 {
-    static const bool is_defined = true;
+    BOOST_STATIC_CONSTEXPR bool is_defined = true;
     typedef one type;
-    static type value() {
-        one result;
-        return(result);
+    static BOOST_CONSTEXPR type value() {
+        return(one());
     }
 };
 
@@ -135,7 +134,7 @@ struct do_call_base_unit_converter {
     typedef typename mpl::divides<source_factor, destination_factor>::type factor;
     typedef eval_scale_list<factor> eval_factor;
     typedef typename multiply_typeof_helper<typename converter::type, typename eval_factor::type>::type type;
-    static type value()
+    static BOOST_CONSTEXPR type value()
     {
         return(converter::value() * eval_factor::value());
     }
@@ -172,9 +171,8 @@ struct call_base_unit_converter_base_unit_impl<false, true>
     {
         typedef do_call_base_unit_converter<Dest, typename Source::unit_type> converter;
         typedef typename divide_typeof_helper<one, typename converter::type>::type type;
-        static type value() {
-            one numerator;
-            return(numerator / converter::value());
+        static BOOST_CONSTEXPR type value() {
+            return(one() / converter::value());
         }
     };
 };
@@ -200,7 +198,7 @@ struct call_base_unit_converter_base_unit_impl<false, false>
             >::type,
             typename end::type
         >::type type;
-        static type value() {
+        static BOOST_CONSTEXPR type value() {
             return(start::value() * conversion::value() / end::value());
         }
     };
@@ -220,7 +218,7 @@ struct get_default_conversion_impl
         typedef typename multiply_typeof_helper<typename power_typeof_helper<new_source, exponent>::type, typename next_iteration::unit_type>::type unit_type;
         typedef call_base_unit_converter<source, new_source> conversion;
         typedef typename multiply_typeof_helper<typename conversion::type, typename next_iteration::type>::type type;
-        static type value() {
+        static BOOST_CONSTEXPR type value() {
             return(static_rational_power<exponent>(conversion::value()) * next_iteration::value());
         }
     };
@@ -234,9 +232,8 @@ struct get_default_conversion_impl<0>
     {
         typedef unit<dimensionless_type, heterogeneous_system<heterogeneous_system_impl<dimensionless_type, dimensionless_type, no_scale> > > unit_type;
         typedef one type;
-        static one value() {
-            one result;
-            return(result);
+        static BOOST_CONSTEXPR one value() {
+            return(one());
         }
     };
 };
@@ -272,7 +269,7 @@ struct call_base_unit_converter_impl<false>
             >::type,
             typename impl::type
         >::type type;
-        static type value() {
+        static BOOST_CONSTEXPR type value() {
             return(start::value() * conversion::value() / impl::value());
         }
     };
@@ -314,7 +311,7 @@ struct conversion_impl
         typedef typename reduce_unit<units::unit<dimensions, DestinationSystem> >::type reduced_unit;
         typedef detail::call_base_unit_converter<unit, reduced_unit> converter;
         typedef typename multiply_typeof_helper<typename converter::type, typename next_iteration::type>::type type;
-        static type value() { return(static_rational_power<typename unit_pair::value_type>(converter::value()) * next_iteration::value()); }
+        static BOOST_CONSTEXPR type value() { return(static_rational_power<typename unit_pair::value_type>(converter::value()) * next_iteration::value()); }
     };
 };
 
@@ -325,7 +322,7 @@ struct conversion_impl<0>
     struct apply
     {
         typedef one type;
-        static type value() { one result; return(result); }
+        static BOOST_CONSTEXPR type value() { return(one()); }
     };
 };
 
@@ -338,11 +335,9 @@ struct conversion_helper<quantity<Unit1, T1>, quantity<Unit2, T2> >
 {
     /// INTERNAL ONLY
     typedef quantity<Unit2, T2> destination_type;
-    static destination_type convert(const quantity<Unit1, T1>& source)
+    static BOOST_CONSTEXPR destination_type convert(const quantity<Unit1, T1>& source)
     {
-        Unit1 u1;
-        Unit2 u2;
-        return(destination_type::from_value(static_cast<T2>(source.value() * conversion_factor(u1, u2))));
+        return(destination_type::from_value(static_cast<T2>(source.value() * conversion_factor(Unit1(), Unit2()))));
     }
 };
 
@@ -365,7 +360,7 @@ struct conversion_factor_helper<unit<D, homogeneous_system<L1> >, unit<D, homoge
     //    homogeneous_system<L2>
     //> impl;
     //typedef typename impl::type type;
-    //static type value()
+    //static BOOST_CONSTEXPR type value()
     //{
     //    return(impl::value());
     //}
@@ -384,7 +379,7 @@ struct conversion_factor_helper<unit<D, heterogeneous_system<L1> >, unit<D, homo
     //> impl;
     //typedef eval_scale_list<typename L1::scale> scale;
     //typedef typename multiply_typeof_helper<typename impl::type, typename scale::type>::type type;
-    //static type value()
+    //static BOOST_CONSTEXPR type value()
     //{
     //    return(impl::value() * scale::value());
     //}
@@ -406,10 +401,9 @@ struct conversion_factor_helper<unit<D, homogeneous_system<L1> >, unit<D, hetero
     //> impl;
     //typedef eval_scale_list<typename L2::scale> scale;
     //typedef typename multiply_typeof_helper<typename impl::type, typename scale::type>::type type;
-    //static type value()
+    //static BOOST_CONSTEXPR type value()
     //{
-    //    one numerator;
-    //    return(numerator / (impl::value() * scale::value()));
+    //    return(one() / (impl::value() * scale::value()));
     //}
 };
 
@@ -443,7 +437,7 @@ struct conversion_factor_helper<unit<D, heterogeneous_system<S1> >, unit<D, hete
         typename conversion1::type,
         typename divide_typeof_helper<typename scale::type, typename conversion2::type>::type
     >::type type;
-    static type value()
+    static BOOST_CONSTEXPR type value()
     {
         return(conversion1::value() * (scale::value() / conversion2::value()));
     }

--- a/include/boost/units/detail/linear_algebra.hpp
+++ b/include/boost/units/detail/linear_algebra.hpp
@@ -598,8 +598,8 @@ struct set_insert<false> {
 
 template<class Set, class T>
 struct has_key {
-    static const long size = sizeof(Set::lookup((wrap<T>*)0));
-    static const bool value = (size == sizeof(set_yes));
+    BOOST_STATIC_CONSTEXPR long size = sizeof(Set::lookup((wrap<T>*)0));
+    BOOST_STATIC_CONSTEXPR bool value = (size == sizeof(set_yes));
 };
 
 template<int N>
@@ -826,7 +826,7 @@ struct normalize_units {
         dimensions
     >::type matrix;
     typedef typename make_square_and_invert<matrix>::type type;
-    static const long extra = (type::size::value) - (T::size::value);
+    BOOST_STATIC_CONSTEXPR long extra = (type::size::value) - (T::size::value);
 };
 
 // multiply_add_units computes M x V
@@ -977,7 +977,7 @@ struct is_simple_system_impl {
                 typename test::base_dimension_type
             >
         > type;
-        static const bool value = (type::value);
+        BOOST_STATIC_CONSTEXPR bool value = (type::value);
     };
 };
 
@@ -1001,7 +1001,7 @@ struct is_simple_system {
             typename test::base_dimension_type
         >
     >::type type;
-    static const bool value = type::value;
+    BOOST_STATIC_CONSTEXPR bool value = type::value;
 };
 
 template<bool>

--- a/include/boost/units/detail/one.hpp
+++ b/include/boost/units/detail/one.hpp
@@ -17,12 +17,11 @@ namespace boost {
 
 namespace units {
 
-struct one { one() {} };
+struct one { BOOST_CONSTEXPR one() {} };
 
 // workaround for pathscale.
-inline one make_one() {
-    one result;
-    return(result);
+inline BOOST_CONSTEXPR one make_one() {
+    return(one());
 }
 
 template<class T>
@@ -44,21 +43,20 @@ struct multiply_typeof_helper<one, one>
 };
 
 template<class T>
-inline T operator*(const one&, const T& t)
+inline BOOST_CONSTEXPR T operator*(const one&, const T& t)
 {
     return(t);
 }
 
 template<class T>
-inline T operator*(const T& t, const one&)
+inline BOOST_CONSTEXPR T operator*(const T& t, const one&)
 {
     return(t);
 }
 
-inline one operator*(const one&, const one&)
+inline BOOST_CONSTEXPR one operator*(const one&, const one&)
 {
-    one result;
-    return(result);
+    return(one());
 }
 
 template<class T>
@@ -80,32 +78,31 @@ struct divide_typeof_helper<one, one>
 };
 
 template<class T>
-inline T operator/(const T& t, const one&)
+inline BOOST_CONSTEXPR T operator/(const T& t, const one&)
 {
     return(t);
 }
 
 template<class T>
-inline T operator/(const one&, const T& t)
+inline BOOST_CONSTEXPR T operator/(const one&, const T& t)
 {
     return(1/t);
 }
 
-inline one operator/(const one&, const one&)
+inline BOOST_CONSTEXPR one operator/(const one&, const one&)
 {
-    one result;
-    return(result);
+    return(one());
 }
 
 template<class T>
-inline bool operator>(const boost::units::one&, const T& t) {
+inline BOOST_CONSTEXPR bool operator>(const boost::units::one&, const T& t) {
     return(1 > t);
 }
 
 template<class T>
-T one_to_double(const T& t) { return t; }
+BOOST_CONSTEXPR T one_to_double(const T& t) { return t; }
 
-inline double one_to_double(const one&) { return 1.0; }
+inline BOOST_CONSTEXPR double one_to_double(const one&) { return 1.0; }
 
 template<class T>
 struct one_to_double_type { typedef T type; };

--- a/include/boost/units/detail/ordinal.hpp
+++ b/include/boost/units/detail/ordinal.hpp
@@ -26,11 +26,11 @@ struct ordinal_tag {};
 template<int N>
 struct ordinal {
     typedef detail::ordinal_tag tag;
-    static const long value = N;
+    BOOST_STATIC_CONSTEXPR long value = N;
 };
 
 template<int N>
-const long ordinal<N>::value;
+BOOST_CONSTEXPR_OR_CONST long ordinal<N>::value;
 
 }
 

--- a/include/boost/units/detail/prevent_redefinition.hpp
+++ b/include/boost/units/detail/prevent_redefinition.hpp
@@ -19,7 +19,7 @@ namespace units {
 
 namespace detail {
 
-struct no { no() {} char dummy; };
+struct no { BOOST_CONSTEXPR no() : dummy() {} char dummy; };
 struct yes { no dummy[2]; };
 
 template<bool> struct ordinal_has_already_been_defined;
@@ -37,15 +37,17 @@ struct ordinal_has_already_been_defined<false>  { typedef void type; };
 /// be found by ADL
 /// INTERNAL ONLY
 template<class T>
+BOOST_CONSTEXPR
 detail::no 
 boost_units_is_registered(const T&) 
-{ detail::no result; return(result); }
+{ return(detail::no()); }
 
 /// INTERNAL ONLY
 template<class T>
+BOOST_CONSTEXPR
 detail::no 
 boost_units_unit_is_registered(const T&) 
-{ detail::no result; return(result); }
+{ return(detail::no()); }
 
 } // namespace units
 

--- a/include/boost/units/detail/static_rational_power.hpp
+++ b/include/boost/units/detail/static_rational_power.hpp
@@ -50,7 +50,7 @@ template<class R, class Y>
 struct static_rational_power_impl
 {
     typedef typename typeof_pow_adl_barrier::typeof_pow<Y>::type type;
-    static type call(const Y& y)
+    static BOOST_CONSTEXPR type call(const Y& y)
     {
         using std::pow;
         return(pow(y, static_cast<double>(R::Numerator) / static_cast<double>(R::Denominator)));
@@ -61,10 +61,9 @@ template<class R>
 struct static_rational_power_impl<R, one>
 {
     typedef one type;
-    static one call(const one&)
+    static BOOST_CONSTEXPR one call(const one&)
     {
-        one result;
-        return(result);
+        return(one());
     }
 };
 
@@ -72,10 +71,9 @@ template<long N>
 struct static_rational_power_impl<static_rational<N, 1>, one>
 {
     typedef one type;
-    static one call(const one&)
+    static BOOST_CONSTEXPR one call(const one&)
     {
-        one result;
-        return(result);
+        return(one());
     }
 };
 
@@ -91,10 +89,9 @@ struct static_int_power_impl<N, true>
         typedef typename multiply_typeof_helper<Y, Y>::type square_type;
         typedef typename static_int_power_impl<(N >> 1)>::template apply<square_type, R> next;
         typedef typename next::type type;
-        static type call(const Y& y, const R& r)
+        static BOOST_CONSTEXPR type call(const Y& y, const R& r)
         {
-            const square_type square = y * y;
-            return(next::call(square, r));
+            return(next::call(static_cast<square_type>(y * y), r));
         }
     };
 };
@@ -109,10 +106,9 @@ struct static_int_power_impl<N, false>
         typedef typename multiply_typeof_helper<Y, R>::type new_r;
         typedef typename static_int_power_impl<(N >> 1)>::template apply<square_type, new_r> next;
         typedef typename next::type type;
-        static type call(const Y& y, const R& r)
+        static BOOST_CONSTEXPR type call(const Y& y, const R& r)
         {
-            const Y square = y * y;
-            return(next::call(square, y * r));
+            return(next::call(static_cast<Y>(y * y), y * r));
         }
     };
 };
@@ -124,7 +120,7 @@ struct static_int_power_impl<1, false>
     struct apply
     {
         typedef typename multiply_typeof_helper<Y, R>::type type;
-        static type call(const Y& y, const R& r)
+        static BOOST_CONSTEXPR type call(const Y& y, const R& r)
         {
             return(y * r);
         }
@@ -138,7 +134,7 @@ struct static_int_power_impl<0, true>
     struct apply
     {
         typedef R type;
-        static R call(const Y&, const R& r)
+        static BOOST_CONSTEXPR R call(const Y&, const R& r)
         {
             return(r);
         }
@@ -156,10 +152,9 @@ struct static_int_power_sign_impl<N, false>
     {
         typedef typename static_int_power_impl<N>::template apply<Y, one> impl;
         typedef typename impl::type type;
-        static type call(const Y& y)
+        static BOOST_CONSTEXPR type call(const Y& y)
         {
-            one result;
-            return(impl::call(y, result));
+            return(impl::call(y, one()));
         }
     };
 };
@@ -172,10 +167,9 @@ struct static_int_power_sign_impl<N, true>
     {
         typedef typename static_int_power_impl<-N>::template apply<Y, one> impl;
         typedef typename divide_typeof_helper<one, typename impl::type>::type type;
-        static type call(const Y& y)
+        static BOOST_CONSTEXPR type call(const Y& y)
         {
-            one result;
-            return(result/impl::call(y, result));
+            return(one()/impl::call(y, one()));
         }
     };
 };
@@ -185,13 +179,14 @@ struct static_rational_power_impl<static_rational<N, 1>, Y>
 {
     typedef typename static_int_power_sign_impl<N>::template apply<Y> impl;
     typedef typename impl::type type;
-    static type call(const Y& y)
+    static BOOST_CONSTEXPR type call(const Y& y)
     {
         return(impl::call(y));
     }
 };
 
 template<class R, class Y>
+BOOST_CONSTEXPR
 typename detail::static_rational_power_impl<R, Y>::type static_rational_power(const Y& y)
 {
     return(detail::static_rational_power_impl<R, Y>::call(y));

--- a/include/boost/units/detail/unscale.hpp
+++ b/include/boost/units/detail/unscale.hpp
@@ -143,7 +143,7 @@ struct eval_scale_list_impl
     {
         typedef typename eval_scale_list_impl<N-1>::template apply<typename Begin::next> next_iteration;
         typedef typename multiply_typeof_helper<typename next_iteration::type, typename Begin::item::value_type>::type type;
-        static type value()
+        static BOOST_CONSTEXPR type value()
         {
             return(next_iteration::value() * Begin::item::value());
         }
@@ -157,10 +157,9 @@ struct eval_scale_list_impl<0>
     struct apply
     {
         typedef one type;
-        static one value()
+        static BOOST_CONSTEXPR one value()
         {
-            one result;
-            return(result);
+            return(one());
         }
     };
 };

--- a/include/boost/units/io.hpp
+++ b/include/boost/units/io.hpp
@@ -669,17 +669,18 @@ template<class T>
 struct autoprefix_norm_impl<T, true>
 {
     typedef double type;
-    static double call(const T& arg) { return std::abs(arg); }
+    static BOOST_CONSTEXPR double call(const T& arg) { return std::abs(arg); }
 };
 
 template<class T>
 struct autoprefix_norm_impl<T, false>
 {
     typedef one type;
-    static one call(const T&) { return one(); }
+    static BOOST_CONSTEXPR one call(const T&) { return one(); }
 };
 
 template<class T>
+BOOST_CONSTEXPR
 typename autoprefix_norm_impl<T>::type autoprefix_norm(const T& arg)
 {
     return autoprefix_norm_impl<T>::call(arg);
@@ -690,12 +691,14 @@ typename autoprefix_norm_impl<T>::type autoprefix_norm(const T& arg)
 namespace detail {
 
 template<class End, class Prev, class T, class F>
+BOOST_CONSTEXPR
 bool find_matching_scale_impl(End, End, Prev, T, double, F)
 {
     return false;
 }
 
 template<class Begin, class End, class Prev, class T, class F>
+BOOST_CXX14_CONSTEXPR
 bool find_matching_scale_impl(Begin, End end, Prev prev, T t, double x, F f)
 {
     if(Begin::item::value() > x) {
@@ -714,12 +717,14 @@ bool find_matching_scale_impl(Begin, End end, Prev prev, T t, double x, F f)
 }
 
 template<class End, class T, class F>
+BOOST_CONSTEXPR
 bool find_matching_scale_i(End, End, T, double, F)
 {
     return false;
 }
 
 template<class Begin, class End, class T, class F>
+BOOST_CXX14_CONSTEXPR
 bool find_matching_scale_i(Begin, End end, T t, double x, F f)
 {
     if(Begin::item::value() > x) {
@@ -730,6 +735,7 @@ bool find_matching_scale_i(Begin, End end, T t, double x, F f)
 }
 
 template<class Scales, class T, class F>
+BOOST_CXX14_CONSTEXPR
 bool find_matching_scale(T t, double x, F f)
 {
     return detail::find_matching_scale_i(Scales(), dimensionless_type(), t, x, f);
@@ -976,8 +982,8 @@ void maybe_print_prefixed(std::basic_ostream<CharT, Traits>& os, const quantity<
     detail::print_default(os, q)();
 }
 
-inline mpl::true_ test_norm(double) { return mpl::true_(); }
-inline mpl::false_ test_norm(one) { return mpl::false_(); }
+inline BOOST_CONSTEXPR mpl::true_ test_norm(double) { return mpl::true_(); }
+inline BOOST_CONSTEXPR mpl::false_ test_norm(one) { return mpl::false_(); }
 
 } // namespace detail
 

--- a/include/boost/units/lambda.hpp
+++ b/include/boost/units/lambda.hpp
@@ -69,7 +69,7 @@ namespace units {
     /// unit<Dim, System> * lambda_functor<Arg>
     /// based on \<boost/lambda/detail/operators.hpp\>.
     template<typename System, typename Dim, typename Arg>
-    inline const typename multiply_typeof_helper<boost::units::unit<Dim, System>, boost::lambda::lambda_functor<Arg> >::type
+    inline BOOST_CONSTEXPR_OR_CONST typename multiply_typeof_helper<boost::units::unit<Dim, System>, boost::lambda::lambda_functor<Arg> >::type
     operator*(const boost::units::unit<Dim, System>& a,
               const boost::lambda::lambda_functor<Arg>& b) {
         return typename multiply_typeof_helper<boost::units::unit<Dim, System>, boost::lambda::lambda_functor<Arg> >::type::inherited
@@ -110,7 +110,7 @@ namespace units {
     /// unit<Dim, System> / lambda_functor<Arg>
     /// based on \<boost/lambda/detail/operators.hpp\>.
     template<typename System, typename Dim, typename Arg>
-    inline const typename divide_typeof_helper<boost::units::unit<Dim, System>, boost::lambda::lambda_functor<Arg> >::type
+    inline BOOST_CONSTEXPR_OR_CONST typename divide_typeof_helper<boost::units::unit<Dim, System>, boost::lambda::lambda_functor<Arg> >::type
     operator/(const boost::units::unit<Dim, System>& a,
               const boost::lambda::lambda_functor<Arg>& b) {
         return typename divide_typeof_helper<boost::units::unit<Dim, System>, boost::lambda::lambda_functor<Arg> >::type::inherited
@@ -151,7 +151,7 @@ namespace units {
     /// lambda_functor<Arg> * unit<Dim, System>
     /// based on \<boost/lambda/detail/operators.hpp\>.
     template<typename System, typename Dim, typename Arg>
-    inline const typename multiply_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::unit<Dim, System> >::type
+    inline BOOST_CONSTEXPR_OR_CONST typename multiply_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::unit<Dim, System> >::type
     operator*(const boost::lambda::lambda_functor<Arg>& a,
               const boost::units::unit<Dim, System>& b) {
         return typename multiply_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::unit<Dim, System> >::type::inherited
@@ -192,7 +192,7 @@ namespace units {
     /// lambda_functor<Arg> / unit<Dim, System>
     /// based on \<boost/lambda/detail/operators.hpp\>.
     template<typename System, typename Dim, typename Arg>
-    inline const typename divide_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::unit<Dim, System> >::type
+    inline BOOST_CONSTEXPR_OR_CONST typename divide_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::unit<Dim, System> >::type
     operator/(const boost::lambda::lambda_functor<Arg>& a,
               const boost::units::unit<Dim, System>& b) {
         return typename divide_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::unit<Dim, System> >::type::inherited
@@ -535,7 +535,7 @@ namespace units {
     /// lambda_functor<Arg> * absolute<unit<Dim, System> >
     /// based on \<boost/lambda/detail/operators.hpp\>.
     template<typename System, typename Dim, typename Arg>
-    inline const typename multiply_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::absolute<boost::units::unit<Dim, System> > >::type
+    inline BOOST_CONSTEXPR_OR_CONST typename multiply_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::absolute<boost::units::unit<Dim, System> > >::type
     operator*(const boost::lambda::lambda_functor<Arg>& a,
               const boost::units::absolute<boost::units::unit<Dim, System> >& b) {
         return typename multiply_typeof_helper<boost::lambda::lambda_functor<Arg>, boost::units::absolute<boost::units::unit<Dim, System> > >::type::inherited
@@ -577,7 +577,7 @@ namespace units {
     /// absolute<unit<Dim, System> > * lambda_functor<Arg>
     /// based on \<boost/lambda/detail/operators.hpp\>.
     template<typename System, typename Dim, typename Arg>
-    inline const typename multiply_typeof_helper<boost::units::absolute<boost::units::unit<Dim, System> >, boost::lambda::lambda_functor<Arg> >::type
+    inline BOOST_CONSTEXPR_OR_CONST typename multiply_typeof_helper<boost::units::absolute<boost::units::unit<Dim, System> >, boost::lambda::lambda_functor<Arg> >::type
     operator*(const boost::units::absolute<boost::units::unit<Dim, System> >& a,
               const boost::lambda::lambda_functor<Arg>& b) {
         return typename multiply_typeof_helper<boost::units::absolute<boost::units::unit<Dim, System> >, boost::lambda::lambda_functor<Arg> >::type::inherited

--- a/include/boost/units/limits.hpp
+++ b/include/boost/units/limits.hpp
@@ -28,46 +28,46 @@ class numeric_limits< ::boost::units::quantity<Unit, T> >
 {
     public:
         typedef ::boost::units::quantity<Unit, T> quantity_type;
-        static const bool is_specialized = std::numeric_limits<T>::is_specialized;
-        static quantity_type (min)() { return(quantity_type::from_value((std::numeric_limits<T>::min)())); }
-        static quantity_type (max)() { return(quantity_type::from_value((std::numeric_limits<T>::max)())); }
+        BOOST_STATIC_CONSTEXPR bool is_specialized = std::numeric_limits<T>::is_specialized;
+        static BOOST_CONSTEXPR quantity_type (min)() { return(quantity_type::from_value((std::numeric_limits<T>::min)())); }
+        static BOOST_CONSTEXPR quantity_type (max)() { return(quantity_type::from_value((std::numeric_limits<T>::max)())); }
 #ifndef BOOST_NO_CXX11_NUMERIC_LIMITS
-        static quantity_type (lowest)() { return(quantity_type::from_value((std::numeric_limits<T>::lowest)())); }
+        static BOOST_CONSTEXPR quantity_type (lowest)() { return(quantity_type::from_value((std::numeric_limits<T>::lowest)())); }
 #endif
-        static const int digits = std::numeric_limits<T>::digits;
-        static const int digits10 = std::numeric_limits<T>::digits10;
+        BOOST_STATIC_CONSTEXPR int digits = std::numeric_limits<T>::digits;
+        BOOST_STATIC_CONSTEXPR int digits10 = std::numeric_limits<T>::digits10;
 #ifndef BOOST_NO_CXX11_NUMERIC_LIMITS
-        static const int max_digits10 = std::numeric_limits<T>::max_digits10;
+        BOOST_STATIC_CONSTEXPR int max_digits10 = std::numeric_limits<T>::max_digits10;
 #endif
-        static const bool is_signed = std::numeric_limits<T>::is_signed;
-        static const bool is_integer = std::numeric_limits<T>::is_integer;
-        static const bool is_exact = std::numeric_limits<T>::is_exact;
-        static const int radix = std::numeric_limits<T>::radix;
-        static quantity_type epsilon()  { return(quantity_type::from_value(std::numeric_limits<T>::epsilon())); }
-        static quantity_type round_error()  { return(quantity_type::from_value(std::numeric_limits<T>::round_error())); }
-        static const int min_exponent = std::numeric_limits<T>::min_exponent;
-        static const int min_exponent10 = std::numeric_limits<T>::min_exponent10;
-        static const int max_exponent = std::numeric_limits<T>::max_exponent;
-        static const int max_exponent10 = std::numeric_limits<T>::max_exponent10;
-        static const bool has_infinity = std::numeric_limits<T>::has_infinity;
-        static const bool has_quiet_NaN = std::numeric_limits<T>::has_quiet_NaN;
-        static const bool has_signaling_NaN = std::numeric_limits<T>::has_signaling_NaN;
-        static const bool has_denorm_loss = std::numeric_limits<T>::has_denorm_loss;
-        static quantity_type infinity()  { return(quantity_type::from_value(std::numeric_limits<T>::infinity())); }
-        static quantity_type quiet_NaN()  { return(quantity_type::from_value(std::numeric_limits<T>::quiet_NaN())); }
-        static quantity_type signaling_NaN()  { return(quantity_type::from_value(std::numeric_limits<T>::signaling_NaN())); }
-        static quantity_type denorm_min()  { return(quantity_type::from_value(std::numeric_limits<T>::denorm_min())); }
-        static const bool is_iec559 = std::numeric_limits<T>::is_iec559;
-        static const bool is_bounded = std::numeric_limits<T>::is_bounded;
-        static const bool is_modulo = std::numeric_limits<T>::is_modulo;
-        static const bool traps = std::numeric_limits<T>::traps;
-        static const bool tinyness_before = std::numeric_limits<T>::tinyness_before;
+        BOOST_STATIC_CONSTEXPR bool is_signed = std::numeric_limits<T>::is_signed;
+        BOOST_STATIC_CONSTEXPR bool is_integer = std::numeric_limits<T>::is_integer;
+        BOOST_STATIC_CONSTEXPR bool is_exact = std::numeric_limits<T>::is_exact;
+        BOOST_STATIC_CONSTEXPR int radix = std::numeric_limits<T>::radix;
+        static BOOST_CONSTEXPR quantity_type epsilon()  { return(quantity_type::from_value(std::numeric_limits<T>::epsilon())); }
+        static BOOST_CONSTEXPR quantity_type round_error()  { return(quantity_type::from_value(std::numeric_limits<T>::round_error())); }
+        BOOST_STATIC_CONSTEXPR int min_exponent = std::numeric_limits<T>::min_exponent;
+        BOOST_STATIC_CONSTEXPR int min_exponent10 = std::numeric_limits<T>::min_exponent10;
+        BOOST_STATIC_CONSTEXPR int max_exponent = std::numeric_limits<T>::max_exponent;
+        BOOST_STATIC_CONSTEXPR int max_exponent10 = std::numeric_limits<T>::max_exponent10;
+        BOOST_STATIC_CONSTEXPR bool has_infinity = std::numeric_limits<T>::has_infinity;
+        BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = std::numeric_limits<T>::has_quiet_NaN;
+        BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = std::numeric_limits<T>::has_signaling_NaN;
+        BOOST_STATIC_CONSTEXPR bool has_denorm_loss = std::numeric_limits<T>::has_denorm_loss;
+        static BOOST_CONSTEXPR quantity_type infinity()  { return(quantity_type::from_value(std::numeric_limits<T>::infinity())); }
+        static BOOST_CONSTEXPR quantity_type quiet_NaN()  { return(quantity_type::from_value(std::numeric_limits<T>::quiet_NaN())); }
+        static BOOST_CONSTEXPR quantity_type signaling_NaN()  { return(quantity_type::from_value(std::numeric_limits<T>::signaling_NaN())); }
+        static BOOST_CONSTEXPR quantity_type denorm_min()  { return(quantity_type::from_value(std::numeric_limits<T>::denorm_min())); }
+        BOOST_STATIC_CONSTEXPR bool is_iec559 = std::numeric_limits<T>::is_iec559;
+        BOOST_STATIC_CONSTEXPR bool is_bounded = std::numeric_limits<T>::is_bounded;
+        BOOST_STATIC_CONSTEXPR bool is_modulo = std::numeric_limits<T>::is_modulo;
+        BOOST_STATIC_CONSTEXPR bool traps = std::numeric_limits<T>::traps;
+        BOOST_STATIC_CONSTEXPR bool tinyness_before = std::numeric_limits<T>::tinyness_before;
 #if defined(_STLP_STATIC_CONST_INIT_BUG)
-        static const int has_denorm = std::numeric_limits<T>::has_denorm;
-        static const int round_style = std::numeric_limits<T>::round_style;
+        BOOST_STATIC_CONSTEXPR int has_denorm = std::numeric_limits<T>::has_denorm;
+        BOOST_STATIC_CONSTEXPR int round_style = std::numeric_limits<T>::round_style;
 #else
-        static const float_denorm_style has_denorm = std::numeric_limits<T>::has_denorm;
-        static const float_round_style round_style = std::numeric_limits<T>::round_style;
+        BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = std::numeric_limits<T>::has_denorm;
+        BOOST_STATIC_CONSTEXPR float_round_style round_style = std::numeric_limits<T>::round_style;
 #endif
 };
 

--- a/include/boost/units/operators.hpp
+++ b/include/boost/units/operators.hpp
@@ -135,7 +135,7 @@ struct power_typeof_helper
     /// specifies the result type
     typedef detail::unspecified type;
     /// Carries out the runtime calculation.
-    static type value(const BaseType& base);
+    static BOOST_CONSTEXPR type value(const BaseType& base);
 };
 
 /// A helper used by @c root to take a root
@@ -152,7 +152,7 @@ struct root_typeof_helper
     /// specifies the result type
     typedef detail::unspecified type;
     /// Carries out the runtime calculation.
-    static type value(const Radicand& base);
+    static BOOST_CONSTEXPR type value(const Radicand& base);
 };
 
 #endif

--- a/include/boost/units/pow.hpp
+++ b/include/boost/units/pow.hpp
@@ -27,6 +27,7 @@ namespace units {
 
 /// raise a value to a @c static_rational power.
 template<class Rat,class Y>
+BOOST_CONSTEXPR
 inline typename power_typeof_helper<Y,Rat>::type
 pow(const Y& x)
 {
@@ -35,6 +36,7 @@ pow(const Y& x)
 
 /// raise a value to an integer power.
 template<long N,class Y>
+BOOST_CONSTEXPR
 inline typename power_typeof_helper<Y,static_rational<N> >::type
 pow(const Y& x)
 {
@@ -51,7 +53,7 @@ struct power_typeof_helper<T, static_rational<N,D> >
     typedef detail::static_rational_power_impl<static_rational<N, D>, internal_type> impl;
     typedef typename impl::type type; 
     
-    static type value(const T& x)  
+    static BOOST_CONSTEXPR type value(const T& x)  
     {
         return impl::call(x);
     }
@@ -64,7 +66,7 @@ struct power_typeof_helper<float, static_rational<N,D> >
     // N.B.  pathscale doesn't accept inheritance for some reason.
     typedef power_typeof_helper<double, static_rational<N,D> > base;
     typedef typename base::type type;
-    static type value(const double& x)
+    static BOOST_CONSTEXPR type value(const double& x)
     {
         return base::value(x);
     }
@@ -74,6 +76,7 @@ struct power_typeof_helper<float, static_rational<N,D> >
 
 /// take the @c static_rational root of a value.
 template<class Rat,class Y>
+BOOST_CONSTEXPR
 typename root_typeof_helper<Y,Rat>::type
 root(const Y& x)
 {
@@ -82,6 +85,7 @@ root(const Y& x)
 
 /// take the integer root of a value.
 template<long N,class Y>
+BOOST_CONSTEXPR
 typename root_typeof_helper<Y,static_rational<N> >::type
 root(const Y& x)
 {
@@ -97,7 +101,7 @@ struct root_typeof_helper<T,static_rational<N,D> >
     // N.B.  pathscale doesn't accept inheritance for some reason.
     typedef power_typeof_helper<T, static_rational<D,N> > base;
     typedef typename base::type type;
-    static type value(const T& x)
+    static BOOST_CONSTEXPR type value(const T& x)
     {
         return(base::value(x));
     }

--- a/include/boost/units/quantity.hpp
+++ b/include/boost/units/quantity.hpp
@@ -98,17 +98,17 @@ class quantity
         typedef Y                                       value_type;
         typedef Unit        unit_type;
  
-        quantity() : val_() 
+        BOOST_CONSTEXPR quantity() : val_() 
         { 
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
         }
 
-        quantity(unspecified_null_pointer_constant_type) : val_() 
+        BOOST_CONSTEXPR quantity(unspecified_null_pointer_constant_type) : val_() 
         { 
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
         }
         
-        quantity(const this_type& source) : val_(source.val_) 
+        BOOST_CONSTEXPR quantity(const this_type& source) : val_(source.val_) 
         {
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
         }
@@ -124,7 +124,7 @@ class quantity
         
         //~quantity() { }
         
-        this_type& operator=(const this_type& source) 
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const this_type& source) 
         { 
              val_ = source.val_; 
              
@@ -135,7 +135,7 @@ class quantity
 
         /// implicit conversion between value types is allowed if allowed for value types themselves
         template<class YY>
-        quantity(const quantity<Unit,YY>& source,
+        BOOST_CONSTEXPR quantity(const quantity<Unit,YY>& source,
             typename boost::enable_if<detail::is_non_narrowing_conversion<YY, Y> >::type* = 0) :
             val_(source.value())
         { 
@@ -144,7 +144,7 @@ class quantity
 
         /// implicit conversion between value types is not allowed if not allowed for value types themselves
         template<class YY>
-        explicit quantity(const quantity<Unit,YY>& source,
+        explicit BOOST_CONSTEXPR quantity(const quantity<Unit,YY>& source,
             typename boost::disable_if<detail::is_non_narrowing_conversion<YY, Y> >::type* = 0) :
             val_(static_cast<Y>(source.value()))
         { 
@@ -155,7 +155,7 @@ class quantity
 
         /// implicit conversion between value types is allowed if allowed for value types themselves
         template<class YY>
-        quantity(const quantity<Unit,YY>& source) :
+        BOOST_CONSTEXPR quantity(const quantity<Unit,YY>& source) :
             val_(source.value())
         { 
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
@@ -166,7 +166,7 @@ class quantity
         
         /// implicit assignment between value types is allowed if allowed for value types themselves
         template<class YY>
-        this_type& operator=(const quantity<Unit,YY>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const quantity<Unit,YY>& source)
         {
             BOOST_STATIC_ASSERT((boost::is_convertible<YY, Y>::value == true));
 
@@ -180,7 +180,7 @@ class quantity
         /// explicit conversion between different unit systems is allowed if implicit conversion is disallowed
         template<class Unit2,class YY> 
         explicit
-        quantity(const quantity<Unit2,YY>& source, 
+        BOOST_CONSTEXPR quantity(const quantity<Unit2,YY>& source, 
                  typename boost::disable_if<
                     mpl::and_<
                         //is_implicitly_convertible should be undefined when the
@@ -198,7 +198,7 @@ class quantity
 
         /// implicit conversion between different unit systems is allowed if each fundamental dimension is implicitly convertible
         template<class Unit2,class YY> 
-        quantity(const quantity<Unit2,YY>& source, 
+        BOOST_CONSTEXPR quantity(const quantity<Unit2,YY>& source, 
                  typename boost::enable_if<
                      mpl::and_<
                          typename is_implicitly_convertible<Unit2,Unit>::type,
@@ -217,7 +217,7 @@ class quantity
         /// without SFINAE we can't distinguish between explicit and implicit conversions so 
         /// the conversion is always explicit
         template<class Unit2,class YY> 
-        explicit quantity(const quantity<Unit2,YY>& source)
+        explicit BOOST_CONSTEXPR quantity(const quantity<Unit2,YY>& source)
              : val_(conversion_helper<quantity<Unit2,YY>,this_type>::convert(source).value())
         {
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
@@ -228,7 +228,7 @@ class quantity
         
         /// implicit assignment between different unit systems is allowed if each fundamental dimension is implicitly convertible 
         template<class Unit2,class YY>
-        this_type& operator=(const quantity<Unit2,YY>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const quantity<Unit2,YY>& source)
         {
             
             BOOST_STATIC_ASSERT((is_implicitly_convertible<Unit2,unit_type>::value == true));
@@ -239,11 +239,11 @@ class quantity
             return *this;
         }
 
-        const value_type& value() const                     { return val_; }                        ///< constant accessor to value
+        BOOST_CONSTEXPR const value_type& value() const     { return val_; }                        ///< constant accessor to value
         
         ///< can add a quantity of the same type if add_typeof_helper<value_type,value_type>::type is convertible to value_type
         template<class Unit2, class YY>
-        this_type& operator+=(const quantity<Unit2, YY>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator+=(const quantity<Unit2, YY>& source)
         {
             BOOST_STATIC_ASSERT((boost::is_same<typename add_typeof_helper<Unit, Unit2>::type, Unit>::value));
             val_ += source.value();
@@ -252,7 +252,7 @@ class quantity
 
         ///< can subtract a quantity of the same type if subtract_typeof_helper<value_type,value_type>::type is convertible to value_type
         template<class Unit2, class YY>
-        this_type& operator-=(const quantity<Unit2, YY>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator-=(const quantity<Unit2, YY>& source)
         {
             BOOST_STATIC_ASSERT((boost::is_same<typename subtract_typeof_helper<Unit, Unit2>::type, Unit>::value));
             val_ -= source.value();
@@ -260,7 +260,7 @@ class quantity
         }  
 
         template<class Unit2, class YY>
-        this_type& operator*=(const quantity<Unit2, YY>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator*=(const quantity<Unit2, YY>& source)
         {
             BOOST_STATIC_ASSERT((boost::is_same<typename multiply_typeof_helper<Unit, Unit2>::type, Unit>::value));
             val_ *= source.value();
@@ -268,7 +268,7 @@ class quantity
         }  
         
         template<class Unit2, class YY>
-        this_type& operator/=(const quantity<Unit2, YY>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator/=(const quantity<Unit2, YY>& source)
         {
             BOOST_STATIC_ASSERT((boost::is_same<typename divide_typeof_helper<Unit, Unit2>::type, Unit>::value));
             val_ /= source.value();
@@ -276,15 +276,15 @@ class quantity
         }
 
         ///< can multiply a quantity by a scalar value_type if multiply_typeof_helper<value_type,value_type>::type is convertible to value_type
-        this_type& operator*=(const value_type& source) { val_ *= source; return *this; }
+        BOOST_CXX14_CONSTEXPR this_type& operator*=(const value_type& source) { val_ *= source; return *this; }
         ///< can divide a quantity by a scalar value_type if divide_typeof_helper<value_type,value_type>::type is convertible to value_type
-        this_type& operator/=(const value_type& source) { val_ /= source; return *this; }
+        BOOST_CXX14_CONSTEXPR this_type& operator/=(const value_type& source) { val_ /= source; return *this; }
     
         /// Construct quantity directly from @c value_type (potentially dangerous).
-        static this_type from_value(const value_type& val)  { return this_type(val, 0); }
+        static BOOST_CONSTEXPR this_type from_value(const value_type& val)  { return this_type(val, 0); }
 
     protected:
-        explicit quantity(const value_type& val, int) : val_(val) { }
+        explicit BOOST_CONSTEXPR quantity(const value_type& val, int) : val_(val) { }
         
     private:
         value_type    val_;
@@ -305,25 +305,25 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
         typedef dimensionless_type                              dimension_type;
         typedef unit<dimension_type,system_type>                unit_type;
          
-        quantity() : val_() 
+        BOOST_CONSTEXPR quantity() : val_() 
         {
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
         }
         
         /// construction from raw @c value_type is allowed
-        quantity(value_type val) : val_(val) 
+        BOOST_CONSTEXPR quantity(value_type val) : val_(val) 
         {
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
         } 
                            
-        quantity(const this_type& source) : val_(source.val_) 
+        BOOST_CONSTEXPR quantity(const this_type& source) : val_(source.val_) 
         {
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
         }
         
         //~quantity() { }
         
-        this_type& operator=(const this_type& source) 
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const this_type& source) 
         { 
             val_ = source.val_; 
                 
@@ -334,7 +334,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
 
         /// implicit conversion between value types is allowed if allowed for value types themselves
         template<class YY>
-        quantity(const quantity<unit<dimension_type,system_type>,YY>& source,
+        BOOST_CONSTEXPR quantity(const quantity<unit<dimension_type,system_type>,YY>& source,
             typename boost::enable_if<detail::is_non_narrowing_conversion<YY, Y> >::type* = 0) :
             val_(source.value())
         { 
@@ -343,7 +343,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
 
         /// implicit conversion between value types is not allowed if not allowed for value types themselves
         template<class YY>
-        explicit quantity(const quantity<unit<dimension_type,system_type>,YY>& source,
+        explicit BOOST_CONSTEXPR quantity(const quantity<unit<dimension_type,system_type>,YY>& source,
             typename boost::disable_if<detail::is_non_narrowing_conversion<YY, Y> >::type* = 0) :
             val_(static_cast<Y>(source.value()))
         { 
@@ -354,7 +354,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
 
         /// implicit conversion between value types is allowed if allowed for value types themselves
         template<class YY>
-        quantity(const quantity<unit<dimension_type,system_type>,YY>& source) :
+        BOOST_CONSTEXPR quantity(const quantity<unit<dimension_type,system_type>,YY>& source) :
             val_(source.value())
         { 
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
@@ -365,7 +365,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
         
         /// implicit assignment between value types is allowed if allowed for value types themselves
         template<class YY>
-        this_type& operator=(const quantity<unit<dimension_type,system_type>,YY>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const quantity<unit<dimension_type,system_type>,YY>& source)
         {
             BOOST_STATIC_ASSERT((boost::is_convertible<YY,Y>::value == true));
 
@@ -378,7 +378,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
 
         /// implicit conversion between different unit systems is allowed
         template<class System2, class Y2> 
-        quantity(const quantity<unit<dimensionless_type, System2>,Y2>& source,
+        BOOST_CONSTEXPR quantity(const quantity<unit<dimensionless_type, System2>,Y2>& source,
         #ifdef __SUNPRO_CC
             typename boost::enable_if<
                 boost::mpl::and_<
@@ -399,7 +399,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
 
         /// implicit conversion between different unit systems is allowed
         template<class System2, class Y2> 
-        explicit quantity(const quantity<unit<dimensionless_type, System2>,Y2>& source,
+        explicit BOOST_CONSTEXPR quantity(const quantity<unit<dimensionless_type, System2>,Y2>& source,
         #ifdef __SUNPRO_CC
             typename boost::enable_if<
                 boost::mpl::and_<
@@ -422,7 +422,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
 
         /// implicit conversion between different unit systems is allowed
         template<class System2, class Y2> 
-        quantity(const quantity<unit<dimensionless_type,homogeneous_system<System2> >,Y2>& source) :
+        BOOST_CONSTEXPR quantity(const quantity<unit<dimensionless_type,homogeneous_system<System2> >,Y2>& source) :
             val_(source.value()) 
         {
             BOOST_UNITS_CHECK_LAYOUT_COMPATIBILITY(this_type, Y);
@@ -434,7 +434,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
         /// conversion between different unit systems is explicit when
         /// the units are not equivalent.
         template<class System2, class Y2> 
-        explicit quantity(const quantity<unit<dimensionless_type, System2>,Y2>& source,
+        explicit BOOST_CONSTEXPR quantity(const quantity<unit<dimensionless_type, System2>,Y2>& source,
             typename boost::disable_if<detail::is_dimensionless_system<System2> >::type* = 0) :
             val_(conversion_helper<quantity<unit<dimensionless_type, System2>,Y2>, this_type>::convert(source).value()) 
         {
@@ -445,7 +445,7 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
 
         /// implicit assignment between different unit systems is allowed
         template<class System2>
-        this_type& operator=(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System2),Y>& source)
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System2),Y>& source)
         {
             *this = this_type(source);
             
@@ -455,24 +455,24 @@ class quantity<BOOST_UNITS_DIMENSIONLESS_UNIT(System),Y>
         #endif
         
         /// implicit conversion to @c value_type is allowed
-        operator value_type() const                         { return val_; }
+        BOOST_CONSTEXPR operator value_type() const                               { return val_; }
         
-        const value_type& value() const                     { return val_; }                        ///< constant accessor to value
+        BOOST_CONSTEXPR const value_type& value() const                           { return val_; }  ///< constant accessor to value
         
         ///< can add a quantity of the same type if add_typeof_helper<value_type,value_type>::type is convertible to value_type
-        this_type& operator+=(const this_type& source)      { val_ += source.val_; return *this; }  
+        BOOST_CXX14_CONSTEXPR this_type& operator+=(const this_type& source)      { val_ += source.val_; return *this; }  
         
         ///< can subtract a quantity of the same type if subtract_typeof_helper<value_type,value_type>::type is convertible to value_type
-        this_type& operator-=(const this_type& source)      { val_ -= source.val_; return *this; }  
+        BOOST_CXX14_CONSTEXPR this_type& operator-=(const this_type& source)      { val_ -= source.val_; return *this; }  
         
         ///< can multiply a quantity by a scalar value_type if multiply_typeof_helper<value_type,value_type>::type is convertible to value_type
-        this_type& operator*=(const value_type& val)        { val_ *= val; return *this; }          
+        BOOST_CXX14_CONSTEXPR this_type& operator*=(const value_type& val)        { val_ *= val; return *this; }          
 
         ///< can divide a quantity by a scalar value_type if divide_typeof_helper<value_type,value_type>::type is convertible to value_type
-        this_type& operator/=(const value_type& val)        { val_ /= val; return *this; }          
+        BOOST_CXX14_CONSTEXPR this_type& operator/=(const value_type& val)        { val_ /= val; return *this; }          
 
         /// Construct quantity directly from @c value_type.
-        static this_type from_value(const value_type& val)  { return this_type(val); }
+        static BOOST_CONSTEXPR this_type from_value(const value_type& val)        { return this_type(val); }
 
    private:
         value_type    val_;
@@ -513,7 +513,7 @@ struct quantity_cast_helper<Y,quantity<Unit,X> >
 {
     typedef Y type;
     
-    type operator()(quantity<Unit,X>& source)           { return const_cast<X&>(source.value()); }
+    BOOST_CONSTEXPR type operator()(quantity<Unit,X>& source) const         { return const_cast<X&>(source.value()); }
 };
 
 /// specialization for casting to the value type
@@ -522,7 +522,7 @@ struct quantity_cast_helper<Y,const quantity<Unit,X> >
 {
     typedef Y type;
     
-    type operator()(const quantity<Unit,X>& source)     { return source.value(); }
+    BOOST_CONSTEXPR type operator()(const quantity<Unit,X>& source) const   { return source.value(); }
 };
 
 } // namespace detail
@@ -530,22 +530,20 @@ struct quantity_cast_helper<Y,const quantity<Unit,X> >
 /// quantity_cast provides mutating access to underlying quantity value_type
 template<class X,class Y>
 inline 
+BOOST_CONSTEXPR
 X
 quantity_cast(Y& source)
 {
-    detail::quantity_cast_helper<X,Y>   qch;
-    
-    return qch(source);
+    return detail::quantity_cast_helper<X,Y>()(source);
 }
 
 template<class X,class Y>
 inline 
+BOOST_CONSTEXPR
 X
 quantity_cast(const Y& source)
 {
-    detail::quantity_cast_helper<X,const Y>   qch;
-    
-    return qch(source);
+    return detail::quantity_cast_helper<X,const Y>()(source);
 }
 
 /// swap quantities
@@ -863,7 +861,7 @@ struct power_typeof_helper< quantity<Unit,Y>,static_rational<N,D> >
     typedef typename power_typeof_helper<Unit,static_rational<N,D> >::type  unit_type;
     typedef quantity<unit_type,value_type>                                  type; 
     
-    static type value(const quantity<Unit,Y>& x)  
+    static BOOST_CONSTEXPR type value(const quantity<Unit,Y>& x)  
     { 
         return type::from_value(power_typeof_helper<Y,static_rational<N,D> >::value(x.value()));
     }
@@ -878,7 +876,7 @@ struct root_typeof_helper< quantity<Unit,Y>,static_rational<N,D> >
     typedef typename root_typeof_helper<Unit,static_rational<N,D> >::type   unit_type;
     typedef quantity<unit_type,value_type>                                  type;
     
-    static type value(const quantity<Unit,Y>& x)  
+    static BOOST_CONSTEXPR type value(const quantity<Unit,Y>& x)  
     { 
         return type::from_value(root_typeof_helper<Y,static_rational<N,D> >::value(x.value()));
     }
@@ -890,6 +888,7 @@ template<class System,
          class Dim,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< unit<Dim,System>,Y >::type
 operator*(const unit<Dim,System>&,const Y& rhs)
 {
@@ -903,6 +902,7 @@ template<class System,
          class Dim,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename divide_typeof_helper< unit<Dim,System>,Y >::type
 operator/(const unit<Dim,System>&,const Y& rhs)
 {
@@ -916,6 +916,7 @@ template<class System,
          class Dim,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< Y,unit<Dim,System> >::type
 operator*(const Y& lhs,const unit<Dim,System>&)
 {
@@ -929,6 +930,7 @@ template<class System,
          class Dim,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename divide_typeof_helper< Y,unit<Dim,System> >::type
 operator/(const Y& lhs,const unit<Dim,System>&)
 {
@@ -942,6 +944,7 @@ operator/(const Y& lhs,const unit<Dim,System>&)
 //         class X,
 //         class Y>
 //inline
+//BOOST_CONSTEXPR
 //typename multiply_typeof_helper< quantity<Unit,X>,Y >::type
 //operator*(const quantity<Unit,X>& lhs,const Y& rhs)
 //{
@@ -955,6 +958,7 @@ operator/(const Y& lhs,const unit<Dim,System>&)
 //         class X,
 //         class Y>
 //inline
+//BOOST_CONSTEXPR
 //typename multiply_typeof_helper< X,quantity<Unit,Y> >::type
 //operator*(const X& lhs,const quantity<Unit,Y>& rhs)
 //{
@@ -967,6 +971,7 @@ operator/(const Y& lhs,const unit<Dim,System>&)
 template<class Unit,
          class X>
 inline
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< quantity<Unit,X>,X >::type
 operator*(const quantity<Unit,X>& lhs,const X& rhs)
 {
@@ -979,6 +984,7 @@ operator*(const quantity<Unit,X>& lhs,const X& rhs)
 template<class Unit,
          class X>
 inline
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< X,quantity<Unit,X> >::type
 operator*(const X& lhs,const quantity<Unit,X>& rhs)
 {
@@ -992,6 +998,7 @@ operator*(const X& lhs,const quantity<Unit,X>& rhs)
 //         class X,
 //         class Y>
 //inline
+//BOOST_CONSTEXPR
 //typename divide_typeof_helper< quantity<Unit,X>,Y >::type
 //operator/(const quantity<Unit,X>& lhs,const Y& rhs)
 //{
@@ -1005,6 +1012,7 @@ operator*(const X& lhs,const quantity<Unit,X>& rhs)
 //         class X,
 //         class Y>
 //inline
+//BOOST_CONSTEXPR
 //typename divide_typeof_helper< X,quantity<Unit,Y> >::type
 //operator/(const X& lhs,const quantity<Unit,Y>& rhs)
 //{
@@ -1017,6 +1025,7 @@ operator*(const X& lhs,const quantity<Unit,X>& rhs)
 template<class Unit,
          class X>
 inline
+BOOST_CONSTEXPR
 typename divide_typeof_helper< quantity<Unit,X>,X >::type
 operator/(const quantity<Unit,X>& lhs,const X& rhs)
 {
@@ -1029,6 +1038,7 @@ operator/(const quantity<Unit,X>& lhs,const X& rhs)
 template<class Unit,
          class X>
 inline
+BOOST_CONSTEXPR
 typename divide_typeof_helper< X,quantity<Unit,X> >::type
 operator/(const X& lhs,const quantity<Unit,X>& rhs)
 {
@@ -1043,6 +1053,7 @@ template<class System1,
          class Unit2,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< unit<Dim1,System1>,quantity<Unit2,Y> >::type
 operator*(const unit<Dim1,System1>&,const quantity<Unit2,Y>& rhs)
 {
@@ -1057,6 +1068,7 @@ template<class System1,
          class Unit2,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename divide_typeof_helper< unit<Dim1,System1>,quantity<Unit2,Y> >::type
 operator/(const unit<Dim1,System1>&,const quantity<Unit2,Y>& rhs)
 {
@@ -1071,6 +1083,7 @@ template<class Unit1,
          class Dim2,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< quantity<Unit1,Y>,unit<Dim2,System2> >::type
 operator*(const quantity<Unit1,Y>& lhs,const unit<Dim2,System2>&)
 {
@@ -1085,6 +1098,7 @@ template<class Unit1,
          class Dim2,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename divide_typeof_helper< quantity<Unit1,Y>,unit<Dim2,System2> >::type
 operator/(const quantity<Unit1,Y>& lhs,const unit<Dim2,System2>&)
 {
@@ -1095,6 +1109,7 @@ operator/(const quantity<Unit1,Y>& lhs,const unit<Dim2,System2>&)
 
 /// runtime unary plus quantity
 template<class Unit,class Y>
+BOOST_CONSTEXPR
 typename unary_plus_typeof_helper< quantity<Unit,Y> >::type
 operator+(const quantity<Unit,Y>& val)
 { 
@@ -1105,6 +1120,7 @@ operator+(const quantity<Unit,Y>& val)
 
 /// runtime unary minus quantity
 template<class Unit,class Y>
+BOOST_CONSTEXPR
 typename unary_minus_typeof_helper< quantity<Unit,Y> >::type
 operator-(const quantity<Unit,Y>& val)
 { 
@@ -1119,6 +1135,7 @@ template<class Unit1,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename add_typeof_helper< quantity<Unit1,X>,quantity<Unit2,Y> >::type
 operator+(const quantity<Unit1,X>& lhs,
           const quantity<Unit2,Y>& rhs)
@@ -1134,6 +1151,7 @@ template<class Unit1,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename subtract_typeof_helper< quantity<Unit1,X>,quantity<Unit2,Y> >::type
 operator-(const quantity<Unit1,X>& lhs,
           const quantity<Unit2,Y>& rhs)
@@ -1149,6 +1167,7 @@ template<class Unit1,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< quantity<Unit1,X>,quantity<Unit2,Y> >::type
 operator*(const quantity<Unit1,X>& lhs,
           const quantity<Unit2,Y>& rhs)
@@ -1165,6 +1184,7 @@ template<class Unit1,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 typename divide_typeof_helper< quantity<Unit1,X>,quantity<Unit2,Y> >::type
 operator/(const quantity<Unit1,X>& lhs,
           const quantity<Unit2,Y>& rhs)
@@ -1180,6 +1200,7 @@ template<class Unit,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 bool 
 operator==(const quantity<Unit,X>& val1,
            const quantity<Unit,Y>& val2)
@@ -1192,6 +1213,7 @@ template<class Unit,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 bool 
 operator!=(const quantity<Unit,X>& val1,
            const quantity<Unit,Y>& val2)
@@ -1204,6 +1226,7 @@ template<class Unit,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 bool 
 operator<(const quantity<Unit,X>& val1,
           const quantity<Unit,Y>& val2)
@@ -1216,6 +1239,7 @@ template<class Unit,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 bool 
 operator<=(const quantity<Unit,X>& val1,
            const quantity<Unit,Y>& val2)
@@ -1228,6 +1252,7 @@ template<class Unit,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 bool 
 operator>(const quantity<Unit,X>& val1,
           const quantity<Unit,Y>& val2)
@@ -1240,6 +1265,7 @@ template<class Unit,
          class X,
          class Y>
 inline
+BOOST_CONSTEXPR
 bool 
 operator>=(const quantity<Unit,X>& val1,
            const quantity<Unit,Y>& val2)

--- a/include/boost/units/scale.hpp
+++ b/include/boost/units/scale.hpp
@@ -37,10 +37,10 @@ struct scaled_base_unit;
 template<long Base, class Exponent>
 struct scale
 {
-    static const long base = Base;
+    BOOST_STATIC_CONSTEXPR long base = Base;
     typedef Exponent exponent;
     typedef double value_type;
-    static value_type value() { return(detail::static_rational_power<Exponent>(static_cast<double>(base))); }
+    static BOOST_CONSTEXPR value_type value() { return(detail::static_rational_power<Exponent>(static_cast<double>(base))); }
     // These need to be defined in specializations for
     // printing to work.
     // static std::string name();
@@ -48,22 +48,22 @@ struct scale
 };
 
 template<long Base, class Exponent>
-const long scale<Base, Exponent>::base;
+BOOST_CONSTEXPR_OR_CONST long scale<Base, Exponent>::base;
 
 /// INTERNAL ONLY
 template<long Base>
 struct scale<Base, static_rational<0> >
 {
-    static const long base = Base;
+    BOOST_STATIC_CONSTEXPR long base = Base;
     typedef static_rational<0> exponent;
     typedef one value_type;
-    static one value() { one result; return(result); }
+    static BOOST_CONSTEXPR one value() { return(one()); }
     static std::string name() { return(""); }
     static std::string symbol() { return(""); }
 };
 
 template<long Base>
-const long scale<Base, static_rational<0> >::base;
+BOOST_CONSTEXPR_OR_CONST long scale<Base, static_rational<0> >::base;
 
 template<long Base,class Exponent>
 std::string symbol_string(const scale<Base,Exponent>&)
@@ -83,10 +83,10 @@ std::string name_string(const scale<Base,Exponent>&)
 template<>                                                                   \
 struct scale<base_, exponent_ >                                              \
 {                                                                            \
-    static const long base = base_;                                          \
+    BOOST_STATIC_CONSTEXPR long base = base_;                                \
     typedef exponent_ exponent;                                              \
     typedef double value_type;                                               \
-    static value_type value()   { return(val_); }                            \
+    static BOOST_CONSTEXPR value_type value()   { return(val_); }            \
     static std::string name()   { return(#name_); }                          \
     static std::string symbol() { return(#symbol_); }                        \
 }

--- a/include/boost/units/static_constant.hpp
+++ b/include/boost/units/static_constant.hpp
@@ -13,9 +13,10 @@
 
 #include <boost/units/config.hpp>
 
+#if defined(BOOST_NO_CXX11_CONSTEXPR) || defined(BOOST_UNITS_DOXYGEN)
 /// A convenience macro that allows definition of static
 /// constants in headers in an ODR-safe way.
-#define BOOST_UNITS_STATIC_CONSTANT(name, type)             \
+# define BOOST_UNITS_STATIC_CONSTANT(name, type)            \
 template<bool b>                                            \
 struct name##_instance_t                                    \
 {                                                           \
@@ -29,6 +30,10 @@ namespace                                                   \
                                                             \
 template<bool b>                                            \
 const type name##_instance_t<b>::instance
+#else
+# define BOOST_UNITS_STATIC_CONSTANT(name, type)            \
+BOOST_STATIC_CONSTEXPR type name
+#endif
 
 /// A convenience macro for static constants with auto 
 /// type deduction. 

--- a/include/boost/units/static_rational.hpp
+++ b/include/boost/units/static_rational.hpp
@@ -114,11 +114,11 @@ class static_rational
             (::boost::mpl::divides<D_type, den_type>::value)
         >  type;
                                  
-        static integer_type numerator()      { return Numerator; }
-        static integer_type denominator()    { return Denominator; }
+        static BOOST_CONSTEXPR integer_type numerator()     { return Numerator; }
+        static BOOST_CONSTEXPR integer_type denominator()   { return Denominator; }
         
         // INTERNAL ONLY
-        static_rational() { }
+        BOOST_CONSTEXPR static_rational() { }
         //~static_rational() { }
 };
 #else
@@ -127,19 +127,19 @@ class static_rational
 {
     private:
 
-        static const integer_type   nabs = static_abs<N>::value,
-                                    dabs = static_abs<D>::value;
+        BOOST_STATIC_CONSTEXPR integer_type nabs = static_abs<N>::value,
+                                            dabs = static_abs<D>::value;
         
         /// greatest common divisor of N and D
         // need cast to signed because static_gcd returns unsigned long
-        static const integer_type   den = 
+        BOOST_STATIC_CONSTEXPR integer_type den = 
             static_cast<integer_type>(boost::integer::static_gcd<nabs,dabs>::value) * ((D < 0) ? -1 : 1);
         
     public: 
         // for mpl arithmetic support
         typedef detail::static_rational_tag tag;
         
-        static const integer_type   Numerator = N/den,
+        BOOST_STATIC_CONSTEXPR integer_type Numerator = N/den,
             Denominator = D/den;
         
         /// INTERNAL ONLY
@@ -148,11 +148,11 @@ class static_rational
         /// static_rational<N,D> reduced by GCD
         typedef static_rational<Numerator,Denominator>  type;
                                  
-        static integer_type numerator()      { return Numerator; }
-        static integer_type denominator()    { return Denominator; }
+        static BOOST_CONSTEXPR integer_type numerator()     { return Numerator; }
+        static BOOST_CONSTEXPR integer_type denominator()   { return Denominator; }
         
         // INTERNAL ONLY
-        static_rational() { }
+        BOOST_CONSTEXPR static_rational() { }
         //~static_rational() { }   
 };
 #endif
@@ -178,7 +178,7 @@ template<integer_type N> class static_rational<N,0>;
 
 /// get decimal value of @c static_rational
 template<class T,integer_type N,integer_type D>
-inline typename divide_typeof_helper<T,T>::type 
+inline BOOST_CONSTEXPR typename divide_typeof_helper<T,T>::type 
 value(const static_rational<N,D>&)
 {
     return T(N)/T(D);

--- a/include/boost/units/systems/detail/constants.hpp
+++ b/include/boost/units/systems/detail/constants.hpp
@@ -31,22 +31,22 @@ template<class Base>
 struct constant 
 { 
     typedef typename Base::value_type value_type; 
-    operator value_type() const    { return Base().value(); } 
-    value_type value() const       { return Base().value(); } 
-    value_type uncertainty() const { return Base().uncertainty(); } 
-    value_type lower_bound() const { return Base().lower_bound(); } 
-    value_type upper_bound() const { return Base().upper_bound(); } 
+    BOOST_CONSTEXPR operator value_type() const    { return Base().value(); } 
+    BOOST_CONSTEXPR value_type value() const       { return Base().value(); } 
+    BOOST_CONSTEXPR value_type uncertainty() const { return Base().uncertainty(); } 
+    BOOST_CONSTEXPR value_type lower_bound() const { return Base().lower_bound(); } 
+    BOOST_CONSTEXPR value_type upper_bound() const { return Base().upper_bound(); } 
 }; 
 
 template<class Base>
 struct physical_constant 
 { 
     typedef typename Base::value_type value_type; 
-    operator value_type() const    { return Base().value(); } 
-    value_type value() const       { return Base().value(); } 
-    value_type uncertainty() const { return Base().uncertainty(); } 
-    value_type lower_bound() const { return Base().lower_bound(); } 
-    value_type upper_bound() const { return Base().upper_bound(); } 
+    BOOST_CONSTEXPR operator value_type() const    { return Base().value(); } 
+    BOOST_CONSTEXPR value_type value() const       { return Base().value(); } 
+    BOOST_CONSTEXPR value_type uncertainty() const { return Base().uncertainty(); } 
+    BOOST_CONSTEXPR value_type lower_bound() const { return Base().lower_bound(); } 
+    BOOST_CONSTEXPR value_type upper_bound() const { return Base().upper_bound(); } 
 }; 
 
 #define BOOST_UNITS_DEFINE_HELPER(name, symbol, template_name)  \
@@ -64,6 +64,7 @@ struct name ## _typeof_helper<template_name<Arg1, Arg2>, constant<T> >\
 };                                                              \
                                                                 \
 template<class T, class Arg1, class Arg2>                       \
+BOOST_CONSTEXPR                                                 \
 typename name ## _typeof_helper<typename T::value_type, template_name<Arg1, Arg2> >::type \
 operator symbol(const constant<T>& t, const template_name<Arg1, Arg2>& u)\
 {                                                               \
@@ -71,6 +72,7 @@ operator symbol(const constant<T>& t, const template_name<Arg1, Arg2>& u)\
 }                                                               \
                                                                 \
 template<class T, class Arg1, class Arg2>                       \
+BOOST_CONSTEXPR                                                 \
 typename name ## _typeof_helper<template_name<Arg1, Arg2>, typename T::value_type>::type \
 operator symbol(const template_name<Arg1, Arg2>& u, const constant<T>& t)\
 {                                                               \
@@ -97,6 +99,7 @@ struct name ## _typeof_helper<constant<T1>, constant<T2> >          \
 };                                                                  \
                                                                     \
 template<class T1, class T2>                                        \
+BOOST_CONSTEXPR                                                     \
 typename name ## _typeof_helper<typename T1::value_type, typename T2::value_type>::type \
 operator symbol(const constant<T1>& t, const constant<T2>& u)       \
 {                                                                   \
@@ -116,6 +119,7 @@ struct name ## _typeof_helper<T1, constant<T2> >                    \
 };                                                                  \
                                                                     \
 template<class T1, class T2>                                        \
+BOOST_CONSTEXPR                                                     \
 typename name ## _typeof_helper<typename T1::value_type, T2>::type  \
 operator symbol(const constant<T1>& t, const T2& u)                 \
 {                                                                   \
@@ -123,6 +127,7 @@ operator symbol(const constant<T1>& t, const T2& u)                 \
 }                                                                   \
                                                                     \
 template<class T1, class T2>                                        \
+BOOST_CONSTEXPR                                                     \
 typename name ## _typeof_helper<T1, typename T2::value_type>::type  \
 operator symbol(const T1& t, const constant<T2>& u)                 \
 {                                                                   \
@@ -151,6 +156,7 @@ struct name ## _typeof_helper<one, constant<T2> >                   \
 };                                                                  \
                                                                     \
 template<class T1>                                                  \
+BOOST_CONSTEXPR                                                     \
 typename name ## _typeof_helper<typename T1::value_type, one>::type \
 operator symbol(const constant<T1>& t, const one& u)                \
 {                                                                   \
@@ -158,6 +164,7 @@ operator symbol(const constant<T1>& t, const one& u)                \
 }                                                                   \
                                                                     \
 template<class T2>                                                  \
+BOOST_CONSTEXPR                                                     \
 typename name ## _typeof_helper<one, typename T2::value_type>::type \
 operator symbol(const one& t, const constant<T2>& u)                \
 {                                                                   \
@@ -174,7 +181,7 @@ struct power_typeof_helper<constant<T1>, static_rational<N,D> >
 {
     typedef power_typeof_helper<typename T1::value_type, static_rational<N,D> > base;
     typedef typename base::type type;
-    static type value(const constant<T1>& arg)
+    static BOOST_CONSTEXPR type value(const constant<T1>& arg)
     {
         return base::value(arg.value());
     }
@@ -189,6 +196,7 @@ struct name ## _typeof_helper<constant<T1> >                        \
 };                                                                  \
                                                                     \
 template<class T1>                                                  \
+BOOST_CONSTEXPR                                                     \
 typename name ## _typeof_helper<typename T1::value_type, one>::type \
 operator symbol(const constant<T1>& t, const one& u)                \
 {                                                                   \
@@ -196,21 +204,22 @@ operator symbol(const constant<T1>& t, const one& u)                \
 }                                                                   \
                                                                     \
 template<class T2>                                                  \
+BOOST_CONSTEXPR                                                     \
 typename name ## _typeof_helper<one, typename T2::value_type>::type \
 operator symbol(const one& t, const constant<T2>& u)                \
 {                                                                   \
     return(t symbol u.value());                                     \
 }
 
-#define BOOST_UNITS_PHYSICAL_CONSTANT(name, type, value_, uncertainty_) \
-struct name ## _t {                                                     \
-    typedef type value_type;                                            \
-    operator value_type() const    { return value_; }                   \
-    value_type value() const       { return value_; }                   \
-    value_type uncertainty() const { return uncertainty_; }             \
-    value_type lower_bound() const { return value_-uncertainty_; }      \
-    value_type upper_bound() const { return value_+uncertainty_; }      \
-};                                                                      \
+#define BOOST_UNITS_PHYSICAL_CONSTANT(name, type, value_, uncertainty_)             \
+struct name ## _t {                                                                 \
+    typedef type value_type;                                                        \
+    BOOST_CONSTEXPR operator value_type() const    { return value_; }               \
+    BOOST_CONSTEXPR value_type value() const       { return value_; }               \
+    BOOST_CONSTEXPR value_type uncertainty() const { return uncertainty_; }         \
+    BOOST_CONSTEXPR value_type lower_bound() const { return value_-uncertainty_; }  \
+    BOOST_CONSTEXPR value_type upper_bound() const { return value_+uncertainty_; }  \
+};                                                                                  \
 BOOST_UNITS_STATIC_CONSTANT(name, boost::units::constant<boost::units::physical_constant<name ## _t> >) = { }
 
 // stream output

--- a/include/boost/units/unit.hpp
+++ b/include/boost/units/unit.hpp
@@ -42,11 +42,11 @@ class unit
         typedef Dim                 dimension_type; 
         typedef System              system_type;
         
-        unit() { }
-        unit(const this_type&) { }
+        BOOST_CONSTEXPR unit() { }
+        BOOST_CONSTEXPR unit(const this_type&) { }
         //~unit() { }  
        
-        this_type& operator=(const this_type&) { return *this; }
+        BOOST_CXX14_CONSTEXPR this_type& operator=(const this_type&) { return *this; }
         
         // sun will ignore errors resulting from templates
         // instantiated in the return type of a function.
@@ -305,7 +305,7 @@ struct power_typeof_helper<unit<Dim,System>,static_rational<N,D> >
 { 
     typedef unit<typename static_power<Dim,static_rational<N,D> >::type,typename static_power<System, static_rational<N,D> >::type>     type; 
     
-    static type value(const unit<Dim,System>&)  
+    static BOOST_CONSTEXPR type value(const unit<Dim,System>&)  
     { 
         return type();
     }
@@ -317,7 +317,7 @@ struct root_typeof_helper<unit<Dim,System>,static_rational<N,D> >
 { 
     typedef unit<typename static_root<Dim,static_rational<N,D> >::type,typename static_root<System, static_rational<N,D> >::type>      type; 
     
-    static type value(const unit<Dim,System>&)  
+    static BOOST_CONSTEXPR type value(const unit<Dim,System>&)  
     { 
         return type();
     }
@@ -325,6 +325,7 @@ struct root_typeof_helper<unit<Dim,System>,static_rational<N,D> >
 
 /// unit runtime unary plus
 template<class Dim,class System>
+BOOST_CONSTEXPR
 typename unary_plus_typeof_helper< unit<Dim,System> >::type
 operator+(const unit<Dim,System>&)
 { 
@@ -335,6 +336,7 @@ operator+(const unit<Dim,System>&)
 
 /// unit runtime unary minus
 template<class Dim,class System>
+BOOST_CONSTEXPR
 typename unary_minus_typeof_helper< unit<Dim,System> >::type
 operator-(const unit<Dim,System>&)
 { 
@@ -348,6 +350,7 @@ template<class Dim1,
          class Dim2,
          class System1,
          class System2>
+BOOST_CONSTEXPR
 typename add_typeof_helper< unit<Dim1,System1>,
                             unit<Dim2,System2> >::type
 operator+(const unit<Dim1,System1>&,const unit<Dim2,System2>&)
@@ -366,6 +369,7 @@ template<class Dim1,
          class Dim2,
          class System1,
          class System2>
+BOOST_CONSTEXPR
 typename subtract_typeof_helper< unit<Dim1,System1>,
                                  unit<Dim2,System2> >::type
 operator-(const unit<Dim1,System1>&,const unit<Dim2,System2>&)
@@ -384,6 +388,7 @@ template<class Dim1,
          class Dim2,
          class System1,
          class System2>
+BOOST_CONSTEXPR
 typename multiply_typeof_helper< unit<Dim1,System1>,
                                  unit<Dim2,System2> >::type
 operator*(const unit<Dim1,System1>&,const unit<Dim2,System2>&)
@@ -399,6 +404,7 @@ template<class Dim1,
          class Dim2,
          class System1,
          class System2>
+BOOST_CONSTEXPR
 typename divide_typeof_helper< unit<Dim1,System1>,
                                unit<Dim2,System2> >::type
 operator/(const unit<Dim1,System1>&,const unit<Dim2,System2>&)
@@ -415,6 +421,7 @@ template<class Dim1,
          class System1,
          class System2>
 inline
+BOOST_CONSTEXPR
 bool 
 operator==(const unit<Dim1,System1>&,const unit<Dim2,System2>&)
 {
@@ -427,6 +434,7 @@ template<class Dim1,
          class System1,
          class System2>
 inline
+BOOST_CONSTEXPR
 bool 
 operator!=(const unit<Dim1,System1>&,const unit<Dim2,System2>&)
 {

--- a/test/test_absolute.cpp
+++ b/test/test_absolute.cpp
@@ -49,18 +49,18 @@ typedef bu::unit<bu::temperature_dimension,bu::make_system<fahrenheit_base_unit>
 
 int test_main(int,char *[])
 {
-    bu::quantity<bu::absolute<fahrenheit_type> > q1(212.0 * bu::absolute<fahrenheit_type>());
-    bu::quantity<bu::absolute<celsius_type> > q2(0.0 * bu::absolute<celsius_type>());
-    bu::quantity<bu::absolute<fahrenheit_type> > q3(q2);
-    bu::quantity<fahrenheit_type> q4(q1 - q3);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::absolute<fahrenheit_type> > q1(212.0 * bu::absolute<fahrenheit_type>());
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::absolute<celsius_type> > q2(0.0 * bu::absolute<celsius_type>());
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::absolute<fahrenheit_type> > q3(q2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<fahrenheit_type> q4(q1 - q3);
 
     BOOST_UNITS_CHECK_CLOSE(q4.value(), 180.0);
 
-    bu::quantity<bu::absolute<kelvin_type> > q5(static_cast<bu::quantity<kelvin_type> >(q4) + static_cast<bu::quantity<bu::absolute<kelvin_type> > >(q2));
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::absolute<kelvin_type> > q5(static_cast<bu::quantity<kelvin_type> >(q4) + static_cast<bu::quantity<bu::absolute<kelvin_type> > >(q2));
 
     BOOST_UNITS_CHECK_CLOSE(q5.value(), 373.15);
 
-    bu::quantity<bu::absolute<fahrenheit_type> > q6(q5);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::absolute<fahrenheit_type> > q6(q5);
 
     BOOST_UNITS_CHECK_CLOSE(q6.value(), 212.0);
 

--- a/test/test_cmath.cpp
+++ b/test/test_cmath.cpp
@@ -29,17 +29,15 @@ Output:
 
 namespace bu = boost::units;
 
-static volatile double  zero = 0;
-
 int test_main(int,char *[])
 {
-    double  inf = std::numeric_limits<double>::infinity(),
-            nan = 0.0/zero;
+    BOOST_CONSTEXPR_OR_CONST double inf = std::numeric_limits<double>::infinity(),
+                                    nan = std::numeric_limits<double>::quiet_NaN();
     
     // default constructor
-    const bu::quantity<bu::energy>          E1(0.0*bu::joules),
-                                            E2(inf*bu::joules),
-                                            E3(nan*bu::joules); 
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy>   E1(0.0*bu::joules),
+                                                        E2(inf*bu::joules),
+                                                        E3(nan*bu::joules); 
     
     BOOST_CHECK((bu::isfinite)(E1) == true);
     BOOST_CHECK((bu::isfinite)(E2) == false);
@@ -57,8 +55,8 @@ int test_main(int,char *[])
     BOOST_CHECK((bu::isnormal)(E2) == false);
     BOOST_CHECK((bu::isnormal)(E3) == false);
 
-    const bu::quantity<bu::energy>          E4(-2.5*bu::joules),
-                                            E5(2.5*bu::joules); 
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy>   E4(-2.5*bu::joules),
+                                                        E5(2.5*bu::joules); 
                                             
     BOOST_CHECK((bu::isgreater)(E4,E5) == false);
     BOOST_CHECK((bu::isgreater)(E5,E4) == true);
@@ -104,10 +102,10 @@ int test_main(int,char *[])
     BOOST_CHECK((bu::fdim)(E4,E5) == 0.0*bu::joules);
     BOOST_CHECK((bu::fdim)(E5,E4) == E5-E4);
     
-    const bu::quantity<bu::length>  L1(3.0*bu::meters),
-                                    L2(4.0*bu::meters);
-    const bu::quantity<bu::area>    A1(4.0*bu::square_meters),
-                                    A2(L1*L2+A1);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::length>   L1(3.0*bu::meters),
+                                                        L2(4.0*bu::meters);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::area>     A1(4.0*bu::square_meters),
+                                                        A2(L1*L2+A1);
 
 #if 0
     BOOST_CHECK((bu::fma)(L1,L2,A1) == A2);
@@ -156,7 +154,7 @@ int test_main(int,char *[])
     BOOST_CHECK(ex == 2);
     BOOST_CHECK((bu::ldexp)(E6,ex) == E4);
     
-    const bu::quantity<bu::dimensionless>   E7(1.0);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>   E7(1.0);
     
     BOOST_CHECK(bu::pow(E7,E7) == 1.0*1.0);
     
@@ -165,7 +163,7 @@ int test_main(int,char *[])
     BOOST_CHECK(std::abs(E8 - std::exp(1.0)) < .000001);
     BOOST_CHECK(bu::log(E8) == E7);
     
-    const bu::quantity<bu::dimensionless>   E9(100.0);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>   E9(100.0);
     
     BOOST_CHECK(bu::log10(E9) == 2.0);
     

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -54,32 +54,32 @@ typedef bu::divide_typeof_helper<bu::multiply_typeof_helper<cgs_mass,mixed_lengt
 
 BOOST_AUTO_TEST_CASE(test_conversion) {
     BOOST_CHECK_EQUAL(1, 1);
-    bu::quantity<mixed_length> a1(2.0 * mixed_length());
-    bu::quantity<si_area> a2(a1);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<mixed_length> a1(2.0 * mixed_length());
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<si_area> a2(a1);
 
     BOOST_UNITS_CHECK_CLOSE(a2.value(), .02);
 
-    bu::quantity<mixed_length> a3(a2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<mixed_length> a3(a2);
 
     BOOST_UNITS_CHECK_CLOSE(a3.value(), 2.0);
 
-    bu::quantity<mixed_energy_1> e1(2.0 * mixed_energy_1());
-    bu::quantity<mixed_energy_2> e2(e1);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<mixed_energy_1> e1(2.0 * mixed_energy_1());
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<mixed_energy_2> e2(e1);
 
     BOOST_UNITS_CHECK_CLOSE(e2.value(), 20.0);
 
-    bu::quantity<bu::si::energy> e3(e1);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::energy> e3(e1);
     BOOST_UNITS_CHECK_CLOSE(e3.value(), .0002);
-    bu::quantity<mixed_energy_2> e4(e3);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<mixed_energy_2> e4(e3);
     BOOST_UNITS_CHECK_CLOSE(e4.value(), 20.0);
 
-    bu::quantity<bu::cgs::force> F0 = 20 * bu::cgs::dyne;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::cgs::force> F0 = 20 * bu::cgs::dyne;
     BOOST_UNITS_CHECK_CLOSE(F0.value(), 20.0);
 
-    bu::quantity<bu::si::force> F3(F0);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::force> F3(F0);
     BOOST_UNITS_CHECK_CLOSE(F3.value(), 2.0e-4);
 
-    bu::quantity<bu::si::force> F5(20 * bu::cgs::dyne);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::force> F5(20 * bu::cgs::dyne);
     BOOST_UNITS_CHECK_CLOSE(F5.value(), 2.0e-4);
 
     // same type
@@ -89,14 +89,14 @@ BOOST_AUTO_TEST_CASE(test_conversion) {
 BOOST_AUTO_TEST_CASE(test_dimensionless_conversions) {
     typedef bu::divide_typeof_helper<bu::cgs::force, bu::si::force>::type mixed_dimensionless;
 
-    bu::quantity<bu::si::dimensionless> dimensionless_test1(1.0*bu::cgs::dyne/bu::si::newton);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::dimensionless> dimensionless_test1(1.0*bu::cgs::dyne/bu::si::newton);
     BOOST_CHECK(dimensionless_test1 == 1e-5);
 
     typedef bu::multiply_typeof_helper<bu::si::length, bu::cgs::length>::type m_cm;
     typedef bu::divide_typeof_helper<m_cm, m_cm>::type heterogeneous_dimensionless;
-    bu::quantity<heterogeneous_dimensionless> dimensionless_test2(1.0*bu::cgs::dyne/bu::si::newton);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<heterogeneous_dimensionless> dimensionless_test2(1.0*bu::cgs::dyne/bu::si::newton);
     BOOST_CHECK(dimensionless_test2.value() == 1e-5);
-    bu::quantity<bu::divide_typeof_helper<bu::cgs::force, bu::si::force>::type> dimensionless_test3(dimensionless_test2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::divide_typeof_helper<bu::cgs::force, bu::si::force>::type> dimensionless_test3(dimensionless_test2);
     BOOST_UNITS_CHECK_CLOSE(dimensionless_test3.value(), 1.0);
 
     BOOST_UNITS_CHECK_CLOSE(boost::units::conversion_factor(mixed_dimensionless(), heterogeneous_dimensionless()), 1e-5);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(test_dimensionless_conversions) {
 
 
     //m/cm -> g/kg
-    bu::quantity<bu::divide_typeof_helper<bu::si::length, bu::cgs::length>::type> dimensionless_test4(2.0 * bu::si::meters / bu::cgs::centimeters);
-    bu::quantity<bu::divide_typeof_helper<bu::cgs::mass, bu::si::mass>::type> dimensionless_test5(dimensionless_test4);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::divide_typeof_helper<bu::si::length, bu::cgs::length>::type> dimensionless_test4(2.0 * bu::si::meters / bu::cgs::centimeters);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::divide_typeof_helper<bu::cgs::mass, bu::si::mass>::type> dimensionless_test5(dimensionless_test4);
     BOOST_UNITS_CHECK_CLOSE(dimensionless_test5.value(), 2e5);
 }

--- a/test/test_default_conversion.cpp
+++ b/test/test_default_conversion.cpp
@@ -54,24 +54,24 @@ BOOST_UNITS_DEFAULT_CONVERSION(unit6_tag, make_unit<unit3_tag>::type);
 BOOST_UNITS_DEFAULT_CONVERSION(unit7_tag, make_unit<unit1_tag>::type);
 
 int test_main(int, char*[]) {
-    double value1 = boost::units::conversion_factor(unit3_tag::unit_type(), unit1_tag::unit_type());
+    BOOST_CONSTEXPR_OR_CONST double value1 = boost::units::conversion_factor(unit3_tag::unit_type(), unit1_tag::unit_type());
     BOOST_CHECK(std::abs(value1 - 1.0/6.0) < .0000000001);
-    double value2 = boost::units::conversion_factor(unit5_tag::unit_type() / unit4_tag::unit_type(), unit1_tag::unit_type());
+    BOOST_CONSTEXPR_OR_CONST double value2 = boost::units::conversion_factor(unit5_tag::unit_type() / unit4_tag::unit_type(), unit1_tag::unit_type());
     BOOST_CHECK(std::abs(value2 - 5.0/6.0) < .0000000001);
     typedef boost::units::scaled_base_unit<unit5_tag, boost::units::scale<2, boost::units::static_rational<1> > > scaled_unit5_tag;
-    double value3 = boost::units::conversion_factor(scaled_unit5_tag::unit_type() / unit4_tag::unit_type(), unit1_tag::unit_type());
+    BOOST_CONSTEXPR_OR_CONST double value3 = boost::units::conversion_factor(scaled_unit5_tag::unit_type() / unit4_tag::unit_type(), unit1_tag::unit_type());
     BOOST_CHECK(std::abs(value3 - 10.0/6.0) < .0000000001);
 
     // check homogeneous unit conversions
-    double value4 = boost::units::conversion_factor(make_unit<unit3_tag>::type(), make_unit<unit1_tag>::type());
+    BOOST_CONSTEXPR_OR_CONST double value4 = boost::units::conversion_factor(make_unit<unit3_tag>::type(), make_unit<unit1_tag>::type());
     BOOST_CHECK(std::abs(value4 - 1.0/6.0) < .0000000001);
-    double value5 = boost::units::conversion_factor(unit3_tag::unit_type(), make_unit<unit1_tag>::type());
+    BOOST_CONSTEXPR_OR_CONST double value5 = boost::units::conversion_factor(unit3_tag::unit_type(), make_unit<unit1_tag>::type());
     BOOST_CHECK(std::abs(value5 - 1.0/6.0) < .0000000001);
-    double value6 = boost::units::conversion_factor(make_unit<unit3_tag>::type(), unit1_tag::unit_type());
+    BOOST_CONSTEXPR_OR_CONST double value6 = boost::units::conversion_factor(make_unit<unit3_tag>::type(), unit1_tag::unit_type());
     BOOST_CHECK(std::abs(value6 - 1.0/6.0) < .0000000001);
 
     // check chained homogeneous conversions
-    double value7 = boost::units::conversion_factor(unit6_tag::unit_type(), unit7_tag::unit_type());
+    BOOST_CONSTEXPR_OR_CONST double value7 = boost::units::conversion_factor(unit6_tag::unit_type(), unit7_tag::unit_type());
     BOOST_CHECK(std::abs(value7 - 5.0/42.0) < .0000000001);
 
     return(0);

--- a/test/test_dimensionless_ice1.cpp
+++ b/test/test_dimensionless_ice1.cpp
@@ -14,7 +14,7 @@
 
 void foo()
 {
-    boost::units::quantity<boost::units::si::dimensionless> d = boost::units::quantity< boost::units::si::dimensionless >();
+    BOOST_CONSTEXPR_OR_CONST boost::units::quantity<boost::units::si::dimensionless> d = boost::units::quantity< boost::units::si::dimensionless >();
     boost::ignore_unused(d);
 }
 

--- a/test/test_dimensionless_ice2.cpp
+++ b/test/test_dimensionless_ice2.cpp
@@ -14,7 +14,7 @@
 
 void foo()
 {
-    boost::units::quantity<boost::units::si::dimensionless> d(1.0 * boost::units::si::meters / boost::units::cgs::centimeters);
+    BOOST_CONSTEXPR_OR_CONST boost::units::quantity<boost::units::si::dimensionless> d(1.0 * boost::units::si::meters / boost::units::cgs::centimeters);
 }
 
 #include <boost/test/test_tools.hpp>

--- a/test/test_dimensionless_quantity.cpp
+++ b/test/test_dimensionless_quantity.cpp
@@ -27,40 +27,40 @@ Output:
 
 namespace bu = boost::units;
 
-static const double E_ = 2.718281828459045235360287471352662497757;
+BOOST_STATIC_CONSTEXPR double E_ = 2.718281828459045235360287471352662497757;
 
 int test_main(int,char *[])
 {
     // default constructor
-    const bu::quantity<bu::dimensionless>           E1; 
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>           E1; 
     BOOST_CHECK(E1.value() == double());
     
     // value_type constructor
-    const bu::quantity<bu::dimensionless>           E2(E_);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>           E2(E_);
     BOOST_CHECK(E2.value() == E_);
 
     // copy constructor
-    const bu::quantity<bu::dimensionless>           E3(E2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>           E3(E2);
     BOOST_CHECK(E3.value() == E_);
 
     // operator=
-    const bu::quantity<bu::dimensionless>           E4 = E2;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>           E4 = E2;
     BOOST_CHECK(E4.value() == E_);
 
     // implicit copy constructor value_type conversion
-    const bu::quantity<bu::dimensionless,float>     E5(E2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless,float>     E5(E2);
     BOOST_UNITS_CHECK_CLOSE(E5.value(), float(E_));
 
-    const bu::quantity<bu::dimensionless,long>      E6(E2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless,long>      E6(E2);
     BOOST_CHECK(E6.value() == long(E_));
 
     // implicit operator= value_type conversion
     // narrowing conversion disallowed
-//    const bu::quantity<bu::dimensionless,float>     E7 = E2;
+//    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless,float>     E7 = E2;
 //    BOOST_UNITS_CHECK_CLOSE(E7.value(),float(E_));
     
     // narrowing conversion disallowed
-//    const bu::quantity<bu::dimensionless,long>      E8 = E2;
+//    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless,long>      E8 = E2;
 //    BOOST_CHECK(E8.value() == long(E_));
     
     // const construction
@@ -104,7 +104,7 @@ int test_main(int,char *[])
     BOOST_CHECK(E9.value() == 1.0);
     
     // static construct quantity from value_type
-    const bu::quantity<bu::dimensionless>           E(bu::quantity<bu::dimensionless>::from_value(2.5));
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>           E(bu::quantity<bu::dimensionless>::from_value(2.5));
     BOOST_CHECK(E.value() == 2.5);
     
     // implicit conversion to value_type
@@ -138,8 +138,8 @@ int test_main(int,char *[])
     // scalar / quantity
     BOOST_CHECK(2.0/E == bu::quantity<bu::dimensionless>::from_value(0.8));
 
-    const bu::quantity<bu::dimensionless>       D1(1.0),
-                                                D2(2.0);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>    D1(1.0),
+                                                                D2(2.0);
     
     // unit * quantity
     BOOST_CHECK(bu::dimensionless()*D1 == D1);
@@ -183,10 +183,10 @@ int test_main(int,char *[])
     // rational root of quantity
     BOOST_CHECK((2.0*bu::root< bu::static_rational<3,2> >(D2) == 2.0*std::pow(2.0,2.0/3.0)*bu::dimensionless()));
     
-    const bu::quantity<bu::dimensionless>   A1(0.0),
-                                            A2(0.0),
-                                            A3(1.0),
-                                            A4(-1.0);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::dimensionless>    A1(0.0),
+                                                                A2(0.0),
+                                                                A3(1.0),
+                                                                A4(-1.0);
                                     
     // operator==
     BOOST_CHECK((A1 == A2) == true);

--- a/test/test_implicit_conversion.cpp
+++ b/test/test_implicit_conversion.cpp
@@ -96,16 +96,16 @@ int test_main(int,char *[])
     BOOST_CHECK((bu::is_implicitly_convertible<bu::cgs::velocity,bu::si::velocity>::value == false));
     BOOST_CHECK((bu::is_implicitly_convertible<bu::cgs::wavenumber,bu::si::wavenumber>::value == false));
     
-    const bu::quantity<bu::si::time>    S1(2.0*bu::si::seconds);
-    const bu::quantity<bu::cgs::time>   S2 = S1;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::time>    S1(2.0*bu::si::seconds);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::cgs::time>   S2 = S1;
 
     BOOST_CHECK((S1.value() == S2.value()));
     
-    const bu::quantity<bu::si::catalytic_activity>  S3(2.0*bu::si::catalytic_activity());
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::catalytic_activity>  S3(2.0*bu::si::catalytic_activity());
     
     
-    const bu::quantity<bu::cgs::time>   C1(2.0*bu::cgs::seconds);
-    const bu::quantity<bu::si::time>    C2 = C1;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::cgs::time>   C1(2.0*bu::cgs::seconds);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::time>    C2 = C1;
 
     BOOST_CHECK((C1.value() == C2.value()));
 

--- a/test/test_information_units.cpp
+++ b/test/test_information_units.cpp
@@ -54,13 +54,13 @@ const double close_fraction = 0.0000001;
 // check transitive conversion factors
 // invariant:  cf(u1,u3) = cf(u1,u2)*cf(u2,u3) 
 #define CHECK_TRANSITIVE_CF(u1, u2, u3) { \
-    double cf12 = bu::conversion_factor((u2), (u1)) ; \
-    double cf23 = bu::conversion_factor((u3), (u2)) ; \
-    double cf13 = bu::conversion_factor((u3), (u1)) ; \
+    BOOST_CONSTEXPR_OR_CONST double cf12 = bu::conversion_factor((u2), (u1)) ; \
+    BOOST_CONSTEXPR_OR_CONST double cf23 = bu::conversion_factor((u3), (u2)) ; \
+    BOOST_CONSTEXPR_OR_CONST double cf13 = bu::conversion_factor((u3), (u1)) ; \
     BOOST_CHECK_CLOSE_FRACTION(cf13, cf12*cf23, close_fraction); \
-    double cf32 = bu::conversion_factor((u2), (u3)) ; \
-    double cf21 = bu::conversion_factor((u1), (u2)) ; \
-    double cf31 = bu::conversion_factor((u1), (u3)) ; \
+    BOOST_CONSTEXPR_OR_CONST double cf32 = bu::conversion_factor((u2), (u3)) ; \
+    BOOST_CONSTEXPR_OR_CONST double cf21 = bu::conversion_factor((u1), (u2)) ; \
+    BOOST_CONSTEXPR_OR_CONST double cf31 = bu::conversion_factor((u1), (u3)) ; \
     BOOST_CHECK_CLOSE_FRACTION(cf31, cf32*cf21, close_fraction); \
 }
 
@@ -105,55 +105,55 @@ BOOST_AUTO_TEST_CASE(test_transitive_byte_nat_hartley) {
 
 BOOST_AUTO_TEST_CASE(test_byte_quantity_is_default) {
     using namespace bu::information;
-    quantity<info, double> qd(2 * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, double> qd(2 * byte);
     BOOST_CHECK_EQUAL(qd.value(), double(2));
-    quantity<info, long> ql(2 * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long> ql(2 * byte);
     BOOST_CHECK_EQUAL(ql.value(), long(2));
 }
 
 BOOST_AUTO_TEST_CASE(test_byte_quantity_explicit) {
     using namespace bu::information;
-    quantity<hu::byte::info, double> qd(2 * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::byte::info, double> qd(2 * byte);
     BOOST_CHECK_EQUAL(qd.value(), double(2));
-    quantity<hu::byte::info, long> ql(2 * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::byte::info, long> ql(2 * byte);
     BOOST_CHECK_EQUAL(ql.value(), long(2));
 }
 
 BOOST_AUTO_TEST_CASE(test_bit_quantity) {
     using namespace bu::information;
-    quantity<hu::bit::info, double> qd(2 * bit);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::bit::info, double> qd(2 * bit);
     BOOST_CHECK_EQUAL(qd.value(), double(2));
-    quantity<hu::bit::info, long> ql(2 * bit);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::bit::info, long> ql(2 * bit);
     BOOST_CHECK_EQUAL(ql.value(), long(2));
 }
 
 BOOST_AUTO_TEST_CASE(test_nat_quantity) {
     using namespace bu::information;
-    quantity<hu::nat::info, double> qd(2 * nat);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::nat::info, double> qd(2 * nat);
     BOOST_CHECK_EQUAL(qd.value(), double(2));
-    quantity<hu::nat::info, long> ql(2 * nat);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::nat::info, long> ql(2 * nat);
     BOOST_CHECK_EQUAL(ql.value(), long(2));
 }
 
 BOOST_AUTO_TEST_CASE(test_hartley_quantity) {
     using namespace bu::information;
-    quantity<hu::hartley::info, double> qd(2 * hartley);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::hartley::info, double> qd(2 * hartley);
     BOOST_CHECK_EQUAL(qd.value(), double(2));
-    quantity<hu::hartley::info, long> ql(2 * hartley);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::hartley::info, long> ql(2 * hartley);
     BOOST_CHECK_EQUAL(ql.value(), long(2));
 }
 
 BOOST_AUTO_TEST_CASE(test_shannon_quantity) {
     using namespace bu::information;
-    quantity<hu::shannon::info, double> qd(2 * shannon);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::shannon::info, double> qd(2 * shannon);
     BOOST_CHECK_EQUAL(qd.value(), double(2));
-    quantity<hu::shannon::info, long> ql(2 * shannon);
+    BOOST_CONSTEXPR_OR_CONST quantity<hu::shannon::info, long> ql(2 * shannon);
     BOOST_CHECK_EQUAL(ql.value(), long(2));
 }
 
 BOOST_AUTO_TEST_CASE(test_mixed_hu) {
     using namespace bu::information;
-    const double cf = 0.001;
+    BOOST_CONSTEXPR_OR_CONST double cf = 0.001;
     BOOST_CHECK_CLOSE_FRACTION((quantity<hu::bit::info>(1.0 * bits)).value(), 1.0, cf);
     BOOST_CHECK_CLOSE_FRACTION((quantity<hu::byte::info>(1.0 * bits)).value(), 1.0/8.0, cf);
     BOOST_CHECK_CLOSE_FRACTION((quantity<hu::nat::info>(1.0 * bits)).value(), 0.69315, cf);
@@ -163,37 +163,37 @@ BOOST_AUTO_TEST_CASE(test_mixed_hu) {
 
 BOOST_AUTO_TEST_CASE(test_info_prefixes) {
     using namespace bu::information;
-    quantity<info, long long> q10(1LL * kibi * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q10(1LL * kibi * byte);
     BOOST_CHECK_EQUAL(q10.value(), 1024LL);
 
-    quantity<info, long long> q20(1LL * mebi * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q20(1LL * mebi * byte);
     BOOST_CHECK_EQUAL(q20.value(), 1048576LL);
 
-    quantity<info, long long> q30(1LL * gibi * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q30(1LL * gibi * byte);
     BOOST_CHECK_EQUAL(q30.value(), 1073741824LL);
 
-    quantity<info, long long> q40(1LL * tebi * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q40(1LL * tebi * byte);
     BOOST_CHECK_EQUAL(q40.value(), 1099511627776LL);
 
-    quantity<info, long long> q50(1LL * pebi * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q50(1LL * pebi * byte);
     BOOST_CHECK_EQUAL(q50.value(), 1125899906842624LL);
 
-    quantity<info, long long> q60(1LL * exbi * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q60(1LL * exbi * byte);
     BOOST_CHECK_EQUAL(q60.value(), 1152921504606846976LL);
 
     using boost::multiprecision::int128_t;
 
-    quantity<info, int128_t> q70(1LL * zebi * byte);
+    const quantity<info, int128_t> q70(1LL * zebi * byte);
     BOOST_CHECK_EQUAL(q70.value(), int128_t("1180591620717411303424"));
 
-    quantity<info, int128_t> q80(1LL * yobi * byte);
+    const quantity<info, int128_t> q80(1LL * yobi * byte);
     BOOST_CHECK_EQUAL(q80.value(), int128_t("1208925819614629174706176"));
 
     // sanity check: si prefixes should also operate
-    quantity<info, long long> q1e3(1LL * si::kilo * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q1e3(1LL * si::kilo * byte);
     BOOST_CHECK_EQUAL(q1e3.value(), 1000LL);
 
-    quantity<info, long long> q1e6(1LL * si::mega * byte);
+    BOOST_CONSTEXPR_OR_CONST quantity<info, long long> q1e6(1LL * si::mega * byte);
     BOOST_CHECK_EQUAL(q1e6.value(), 1000000LL);
 }
 

--- a/test/test_mixed_value_types.cpp
+++ b/test/test_mixed_value_types.cpp
@@ -16,7 +16,7 @@ namespace bu = boost::units;
 
 int main() {
     bu::quantity<bu::si::length, double> q1;
-    bu::quantity<bu::si::length, int> q2;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::si::length, int> q2;
     q1 + q2;
     q1 -= q2;
 }

--- a/test/test_output.cpp
+++ b/test/test_output.cpp
@@ -44,18 +44,18 @@ Tests for output from various units, name, symbol and raw formats, and automatic
 #include <boost/test/unit_test.hpp>
 
 struct meter_base_unit : boost::units::base_unit<meter_base_unit, boost::units::length_dimension, 1> {
-    static const char* name() { return("meter"); }
-    static const char* symbol() { return("m"); }
+    static BOOST_CONSTEXPR const char* name() { return("meter"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("m"); }
 };
 
 struct second_base_unit : boost::units::base_unit<second_base_unit, boost::units::time_dimension, 2> {
-    static const char* name() { return("second"); }
-    static const char* symbol() { return("s"); }
+    static BOOST_CONSTEXPR const char* name() { return("second"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("s"); }
 };
 
 struct byte_base_unit : boost::units::base_unit<byte_base_unit, boost::units::dimensionless_type, 3> {
-    static const char* name() { return("byte"); }
-    static const char* symbol() { return("b"); }
+    static BOOST_CONSTEXPR const char* name() { return("byte"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("b"); }
 };
 
 typedef boost::units::make_system<meter_base_unit, second_base_unit>::type my_system;
@@ -83,8 +83,8 @@ namespace boost {
 namespace units {
 template<>
 struct base_unit_info<scaled_length_base_unit> {
-    static const char* symbol() { return("scm"); }
-    static const char* name() { return("scaled_meter"); }
+    static BOOST_CONSTEXPR const char* symbol() { return("scm"); }
+    static BOOST_CONSTEXPR const char* name() { return("scaled_meter"); }
 };
 }
 }
@@ -98,8 +98,8 @@ std::string symbol_string(const custom1&) { return("c1"); }
 
 typedef boost::units::reduce_unit<boost::units::unit<boost::units::acceleration_dimension, my_system> >::type custom2;
 
-const char* name_string(const custom2&) { return("custom2"); }
-const char* symbol_string(const custom2&) { return("c2"); }
+BOOST_CONSTEXPR const char* name_string(const custom2&) { return("custom2"); }
+BOOST_CONSTEXPR const char* symbol_string(const custom2&) { return("c2"); }
 
 typedef boost::units::make_scaled_unit<custom1, boost::units::scale<10, boost::units::static_rational<3> > >::type scaled_custom1;
 typedef boost::units::make_scaled_unit<custom2, boost::units::scale<10, boost::units::static_rational<3> > >::type scaled_custom2;

--- a/test/test_quantity.cpp
+++ b/test/test_quantity.cpp
@@ -27,35 +27,35 @@ Output:
 
 namespace bu = boost::units;
 
-static const double E_ = 2.718281828459045235360287471352662497757;
+BOOST_STATIC_CONSTEXPR double E_ = 2.718281828459045235360287471352662497757;
 
 int test_main(int,char *[])
 {
     // default constructor
-    const bu::quantity<bu::energy>          E1; 
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy>          E1; 
     BOOST_CHECK(E1.value() == double());
     
     // value_type constructor
-    const bu::quantity<bu::energy>          E2(E_*bu::joules);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy>          E2(E_*bu::joules);
     BOOST_CHECK(E2.value() == E_);
 
     // copy constructor
-    const bu::quantity<bu::energy>          E3(E2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy>          E3(E2);
     BOOST_CHECK(E3.value() == E_);
 
     // operator=
-    const bu::quantity<bu::energy>          E4 = E2;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy>          E4 = E2;
     BOOST_CHECK(E4.value() == E_);
 
     // implicit copy constructor value_type conversion
-    const bu::quantity<bu::energy,float>    E5(E2);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy,float>    E5(E2);
     BOOST_UNITS_CHECK_CLOSE(E5.value(),float(E_));
 
     // implicit operator= value_type conversion
-    //const bu::quantity<bu::energy,float>    E7 = E2;
+    //BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy,float>    E7 = E2;
     //BOOST_UNITS_CHECK_CLOSE(E7.value(),float(E_));
     
-    //const bu::quantity<bu::energy,long>     E8 = E2;
+    //BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy,long>     E8 = E2;
     //BOOST_CHECK(E8.value() == long(E_));
     
     // const construction
@@ -91,7 +91,7 @@ int test_main(int,char *[])
     BOOST_CHECK(E9.value() == 1.0);
     
     // static construct quantity from value_type
-    const bu::quantity<bu::energy>      E(bu::quantity<bu::energy>::from_value(2.5));
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::energy>      E(bu::quantity<bu::energy>::from_value(2.5));
     BOOST_CHECK(E.value() == 2.5);
     
     // quantity_cast
@@ -120,10 +120,10 @@ int test_main(int,char *[])
     // scalar / quantity
     BOOST_CHECK(2.0/E == bu::quantity<bu::inverse_energy>::from_value(0.8));
 
-    const bu::quantity<bu::length>      L(1.0*bu::meters);
-    const bu::quantity<bu::mass>        M(2.0*bu::kilograms);
-    const bu::quantity<bu::time>        T(3.0*bu::seconds);
-    const bu::quantity<bu::velocity>    V(bu::quantity<bu::velocity>::from_value(4.0));
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::length>      L(1.0*bu::meters);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::mass>        M(2.0*bu::kilograms);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::time>        T(3.0*bu::seconds);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::velocity>    V(bu::quantity<bu::velocity>::from_value(4.0));
     
     // unit * quantity
     BOOST_CHECK(bu::seconds*V == 4.0*bu::meters);
@@ -155,8 +155,8 @@ int test_main(int,char *[])
     // quantity / quantity
     BOOST_CHECK(L/V == 0.25*bu::seconds);
     
-    const bu::quantity<bu::area>    A(2.0*bu::square_meters);
-    const bu::quantity<bu::volume>  VL(1.0*bu::cubic_meters);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::area>    A(2.0*bu::square_meters);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::volume>  VL(1.0*bu::cubic_meters);
     
     // integer power of quantity
     BOOST_CHECK(2.0*bu::pow<2>(L) == A);
@@ -170,10 +170,10 @@ int test_main(int,char *[])
     // rational root of quantity
     BOOST_CHECK((bu::root< bu::static_rational<3,2> >(VL) == 0.5*A));
     
-    const bu::quantity<bu::area>    A1(0.0*bu::square_meters),
-                                    A2(0.0*bu::square_meters),
-                                    A3(1.0*bu::square_meters),
-                                    A4(-1.0*bu::square_meters);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<bu::area> A1(0.0*bu::square_meters),
+                                                    A2(0.0*bu::square_meters),
+                                                    A3(1.0*bu::square_meters),
+                                                    A4(-1.0*bu::square_meters);
                                     
     // operator==
     BOOST_CHECK((A1 == A2) == true);

--- a/test/test_scaled_unit.cpp
+++ b/test/test_scaled_unit.cpp
@@ -37,23 +37,23 @@ namespace bu = boost::units;
 namespace si = boost::units::si;
 
 BOOST_AUTO_TEST_CASE(test_scaled_to_plain) {
-    bu::quantity<si::time> s1 = 12.5 * si::seconds;
-    bu::quantity<si::time> s2(si::nano * s1);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<si::time> s1 = 12.5 * si::seconds;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<si::time> s2(si::nano * s1);
     BOOST_CHECK_CLOSE_FRACTION(1e-9 * s1.value(), s2.value(), 0.000000001);
 }
 
 BOOST_AUTO_TEST_CASE(test_plain_to_scaled) {
-    bu::quantity<si::time> s1 = 12.5 * si::seconds;
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<si::time> s1 = 12.5 * si::seconds;
     typedef bu::multiply_typeof_helper<si::nano_type, si::time>::type time_unit;
-    bu::quantity<time_unit> s2(s1);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<time_unit> s2(s1);
     BOOST_CHECK_CLOSE_FRACTION(1e9 * s1.value(), s2.value(), 0.000000001);
 }
 
 BOOST_AUTO_TEST_CASE(test_scaled_to_scaled) {
     typedef bu::multiply_typeof_helper<si::mega_type, si::time>::type mega_time_unit;
     typedef bu::multiply_typeof_helper<si::micro_type, si::time>::type micro_time_unit;
-    bu::quantity<mega_time_unit> s1(12.5 * si::seconds);
-    bu::quantity<micro_time_unit> s2(s1);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<mega_time_unit> s1(12.5 * si::seconds);
+    BOOST_CONSTEXPR_OR_CONST bu::quantity<micro_time_unit> s2(s1);
     BOOST_CHECK_CLOSE_FRACTION(1e12 * s1.value(), s2.value(), 0.000000001);
 }
 

--- a/test/test_unit.cpp
+++ b/test/test_unit.cpp
@@ -29,11 +29,11 @@ namespace bu = boost::units;
 
 int test_main(int,char *[])
 {
-    const bu::dimensionless D;
+    BOOST_CONSTEXPR_OR_CONST bu::dimensionless D;
     
-    const bu::length        L;
-    const bu::mass          M;
-    const bu::time          T;
+    BOOST_CONSTEXPR_OR_CONST bu::length        L;
+    BOOST_CONSTEXPR_OR_CONST bu::mass          M;
+    BOOST_CONSTEXPR_OR_CONST bu::time          T;
     
     BOOST_CHECK(+L == L);
     BOOST_CHECK(-L == L);
@@ -45,9 +45,9 @@ int test_main(int,char *[])
     BOOST_CHECK(M+M == M);
     BOOST_CHECK(M-M == M);
     
-    const bu::area          A;
-    const bu::energy        E;
-    const bu::velocity      V;
+    BOOST_CONSTEXPR_OR_CONST bu::area          A;
+    BOOST_CONSTEXPR_OR_CONST bu::energy        E;
+    BOOST_CONSTEXPR_OR_CONST bu::velocity      V;
     
     BOOST_CHECK(L*L == A);
     BOOST_CHECK(A == L*L);


### PR DESCRIPTION
This adds `constexpr` support to most of Boost.Units. Most importantly to the `unit` and `quantity` classes.

This allows using these types in `constexpr` functions.

I've tested this with GCC 5.4.0 and Clang 3.8.0 on Debian Stretch, compiling and running all the tests and examples for `-std=c++98`, `-std=c++03`, `-std=c++11`, `std=c++14`.

My test runs of example/performance.cpp appeared to show a slight improvement for the ublas::matrix case compared to before this change. But the numbers seem to vary a lot so I suspect it's probably no significant difference at all. For Clang I do notice that with this change included, when compiling for C++11 or C++14 the size of the `performance` executable drops from 2.6M to 2.4M.

Furthermore, when testing with Clang's `-emit-llvm` option with and without this changes shows that (global) constants (`static const quantity<some_unit> TheConstant`) now get constant propagated better. I.e. without this change a simple function returning the product of two constants would first get these from memory (`getelementptr`) and multiply them. With this change the result of the multiplication is inlined and returned directly.
