### PR TITLE
Make comparisons between heterogenous and homogenous quantities possible 

### DIFF
--- a/include/boost/units/quantity.hpp
+++ b/include/boost/units/quantity.hpp
@@ -1176,75 +1176,99 @@ operator/(const quantity<Unit1,X>& lhs,
 }
 
 /// runtime operator==
-template<class Unit,
+template<class Unit1,
+         class Unit2,
          class X,
          class Y>
 inline
-bool 
-operator==(const quantity<Unit,X>& val1,
-           const quantity<Unit,Y>& val2)
+typename boost::enable_if<
+    typename is_implicitly_convertible<Unit1, Unit2>::type,
+    bool
+>::type
+operator==(const quantity<Unit1,X>& val1,
+           const quantity<Unit2,Y>& val2)
 {
-    return val1.value() == val2.value();
+    return val1.value() == quantity<Unit1, Y>(val2).value();
 }
 
 /// runtime operator!=
-template<class Unit,
+template<class Unit1,
+         class Unit2,
          class X,
          class Y>
 inline
-bool 
-operator!=(const quantity<Unit,X>& val1,
-           const quantity<Unit,Y>& val2)
+typename boost::enable_if<
+    typename is_implicitly_convertible<Unit1, Unit2>::type,
+    bool
+>::type
+operator!=(const quantity<Unit1,X>& val1,
+           const quantity<Unit2,Y>& val2)
 {
-    return val1.value() != val2.value();
+    return val1.value() != quantity<Unit1, Y>(val2).value();
 }
 
 /// runtime operator<
-template<class Unit,
+template<class Unit1,
+         class Unit2,
          class X,
          class Y>
 inline
-bool 
-operator<(const quantity<Unit,X>& val1,
-          const quantity<Unit,Y>& val2)
+typename boost::enable_if<
+    typename is_implicitly_convertible<Unit1, Unit2>::type,
+    bool
+>::type
+operator<(const quantity<Unit1,X>& val1,
+          const quantity<Unit2,Y>& val2)
 {
-    return val1.value() < val2.value();
+    return val1.value() < quantity<Unit1, Y>(val2).value();
 }
 
 /// runtime operator<=
-template<class Unit,
+template<class Unit1,
+         class Unit2,
          class X,
          class Y>
 inline
-bool 
-operator<=(const quantity<Unit,X>& val1,
-           const quantity<Unit,Y>& val2)
+typename boost::enable_if<
+    typename is_implicitly_convertible<Unit1, Unit2>::type,
+    bool
+>::type
+operator<=(const quantity<Unit1,X>& val1,
+           const quantity<Unit2,Y>& val2)
 {
-    return val1.value() <= val2.value();
+    return val1.value() <= quantity<Unit1, Y>(val2).value();
 }
 
 /// runtime operator>
-template<class Unit,
+template<class Unit1,
+         class Unit2,
          class X,
          class Y>
 inline
-bool 
-operator>(const quantity<Unit,X>& val1,
-          const quantity<Unit,Y>& val2)
+typename boost::enable_if<
+    typename is_implicitly_convertible<Unit1, Unit2>::type,
+    bool
+>::type
+operator>(const quantity<Unit1,X>& val1,
+          const quantity<Unit2,Y>& val2)
 {
-    return val1.value() > val2.value();
+    return val1.value() > quantity<Unit1, Y>(val2).value();
 }
 
 /// runtime operator>=
-template<class Unit,
+template<class Unit1,
+         class Unit2,
          class X,
          class Y>
 inline
-bool 
-operator>=(const quantity<Unit,X>& val1,
-           const quantity<Unit,Y>& val2)
+typename boost::enable_if<
+    typename is_implicitly_convertible<Unit1, Unit2>::type,
+    bool
+>::type
+operator>=(const quantity<Unit1,X>& val1,
+           const quantity<Unit2,Y>& val2)
 {
-    return val1.value() >= val2.value();
+    return val1.value() >= quantity<Unit1, Y>(val2).value();
 }
 
 } // namespace units

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -27,6 +27,7 @@ project boost/units/test :
 
 alias test_framework : /boost//unit_test_framework/<warnings-as-errors>off ;
 
+compile-fail test_heterogenous_comparison.cpp ;
 compile test_predicates.cpp ;
 compile test_negative_denominator.cpp ;
 compile test_dimensionless_ice1.cpp ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -27,7 +27,7 @@ project boost/units/test :
 
 alias test_framework : /boost//unit_test_framework/<warnings-as-errors>off ;
 
-compile-fail test_heterogenous_comparison.cpp ;
+compile test_heterogenous_comparison.cpp ;
 compile test_predicates.cpp ;
 compile test_negative_denominator.cpp ;
 compile test_dimensionless_ice1.cpp ;

--- a/test/test_heterogenous_comparison.cpp
+++ b/test/test_heterogenous_comparison.cpp
@@ -1,0 +1,38 @@
+// Boost.Units - A C++ library for zero-overhead dimensional analysis and
+// unit/quantity manipulation and conversion
+//
+// Copyright (C) 2016 Giel van Schijndel
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/**
+\file
+
+\brief test_heterogenous_comparison.cpp
+
+\details
+Verify that comparing a quantity from a heterogenous system with a
+quantity from a homogenous system works.
+
+Output:
+@verbatim
+@endverbatim
+**/
+
+#include <boost/units/quantity.hpp>
+#include <boost/units/systems/si/length.hpp>
+
+namespace bu = boost::units;
+
+int main(int,char *[])
+{
+    bu::quantity<bu::si::meter_base_unit::unit_type> x;
+    int y = 0;
+
+    x < y * bu::si::meter;
+
+    return 0;
+}
+


### PR DESCRIPTION
Make comparisons between heterogenous and homogenous quantities possible .

And add a test case that fails without this change.

NOTE that the explicit conversion to `quantity<Unit1, Y>` is probably not necessary. It definitely isn't necessary if conversion_factor(Unit2(), Unit1()) == 1, and I believe that it is. Unfortunately I haven't been able to verify that through reviewing the code involved in computing the conversion factor.