### PR TITLE
Fix bogus encoding of Euro symbol, use UTF-8

### DIFF
--- a/example/autoprefixes.cpp
+++ b/example/autoprefixes.cpp
@@ -67,7 +67,7 @@ struct thing_base_unit : boost::units::base_unit<thing_base_unit, boost::units::
 struct euro_base_unit : boost::units::base_unit<euro_base_unit, boost::units::dimensionless_type, 5>
 {
   static constexpr const char* name() { return("EUR"); }
-  static constexpr const char* symbol() { return("€"); }
+  static constexpr const char* symbol() { return("â‚¬"); }
 };
 
 int main()
@@ -140,7 +140,7 @@ int main()
 
   quantity<euro_base_unit::unit_type> ce = 2048. * euro_base_unit::unit_type();
   cout << name_format << engineering_prefix << ce << endl;  // 2.048 kiloEUR
-  cout << symbol_format << engineering_prefix << ce << endl;  // 2.048 k€
+  cout << symbol_format << engineering_prefix << ce << endl;  // 2.048 kâ‚¬
 
 
     return 0;


### PR DESCRIPTION
Fixed this ancient issue: https://svn.boost.org/trac10/ticket/6150