### PR TITLE
Use more decimals for Pi in angle conversions

### DIFF
--- a/include/boost/units/base_units/angle/degree.hpp
+++ b/include/boost/units/base_units/angle/degree.hpp
@@ -14,7 +14,7 @@
 #include <boost/units/conversion.hpp>
 #include <boost/units/base_units/angle/radian.hpp>
 
-BOOST_UNITS_DEFINE_BASE_UNIT_WITH_CONVERSIONS(angle,degree,"degree","deg",6.28318530718/360.,boost::units::angle::radian_base_unit,-101);
+BOOST_UNITS_DEFINE_BASE_UNIT_WITH_CONVERSIONS(angle,degree,"degree","deg",6.283185307179586/360.,boost::units::angle::radian_base_unit,-101);
 
 #if BOOST_UNITS_HAS_BOOST_TYPEOF
 

--- a/include/boost/units/base_units/angle/gradian.hpp
+++ b/include/boost/units/base_units/angle/gradian.hpp
@@ -14,7 +14,7 @@
 #include <boost/units/conversion.hpp>
 #include <boost/units/base_units/angle/radian.hpp>
 
-BOOST_UNITS_DEFINE_BASE_UNIT_WITH_CONVERSIONS(angle,gradian,"gradian","grad",6.28318530718/400.,boost::units::angle::radian_base_unit,-102);
+BOOST_UNITS_DEFINE_BASE_UNIT_WITH_CONVERSIONS(angle,gradian,"gradian","grad",6.283185307179586/400.,boost::units::angle::radian_base_unit,-102);
 
 #if BOOST_UNITS_HAS_BOOST_TYPEOF
 


### PR DESCRIPTION
The previous value had twelve signficant digits which is quite below the maximum precision of double floating numbers.
In this change the value returned by Python for the expression math.pi * 2 is used. This value is the same as the one returned by std::cos(-1) * 2 with 16 significant digits.