### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(boost_units
     Boost::math
     Boost::mpl
     Boost::preprocessor
-    Boost::static_assert
     Boost::type_traits
     Boost::typeof
 )

--- a/build.jam
+++ b/build.jam
@@ -16,7 +16,6 @@ constant boost_dependencies :
     /boost/move//boost_move
     /boost/mpl//boost_mpl
     /boost/preprocessor//boost_preprocessor
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits
     /boost/typeof//boost_typeof ;
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.